### PR TITLE
Support for quoted types, pythonic script generation, strict DATE regex

### DIFF
--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -440,8 +440,7 @@ def convert_type(atype, btype):
 def is_string_type(thetype):
     """Returns true if the type is one of: STRING, TIMESTAMP, DATE, or
     TIME."""
-    return (thetype == 'STRING' or thetype == 'TIMESTAMP' or
-            thetype == 'DATE' or thetype == 'TIME')
+    return thetype in ['STRING', 'TIMESTAMP', 'DATE', 'TIME', 'QINTEGER', 'QFLOAT', 'QBOOLEAN']
 
 
 def flatten_schema_map(schema_map, keep_nulls=False):

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -50,7 +50,7 @@ class SchemaGenerator:
         r'(([+-]\d{1,2}(:\d{1,2})?)|Z)?$')
 
     # Detect a DATE field of the form YYYY-[M]M-[D]D.
-    DATE_MATCHER = re.compile(r'^\d{4}-(?:0[1-9]|1[012])-(?:0[1-9]|[12][0-9]|3[01])$')
+    DATE_MATCHER = re.compile(r'^\d{4}-(?:[1-9]|0[1-9]|1[012])-(?:[1-9]|0[1-9]|[12][0-9]|3[01])$')
 
     # Detect a TIME field of the form [H]H:[M]M:[S]S[.DDDDDD]
     TIME_MATCHER = re.compile(r'^\d{1,2}:\d{1,2}:\d{1,2}(\.\d{1,6})?$')

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -50,7 +50,7 @@ class SchemaGenerator:
         r'(([+-]\d{1,2}(:\d{1,2})?)|Z)?$')
 
     # Detect a DATE field of the form YYYY-[M]M-[D]D.
-    DATE_MATCHER = re.compile(r'^\d{4}-\d{1,2}-\d{1,2}$')
+    DATE_MATCHER = re.compile(r'^\d{4}-(?:0[1-9]|1[012])-(?:0[1-9]|[12][0-9]|3[01])$')
 
     # Detect a TIME field of the form [H]H:[M]M:[S]S[.DDDDDD]
     TIME_MATCHER = re.compile(r'^\d{1,2}:\d{1,2}:\d{1,2}(\.\d{1,6})?$')

--- a/scripts/generate-schema
+++ b/scripts/generate-schema
@@ -1,1 +1,0 @@
-python3 -m bigquery_schema_generator.generate_schema "$@"

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,10 @@ setup(name='bigquery-schema-generator',
       author_email='brian@xparks.net',
       license='Apache 2.0',
       packages=['bigquery_schema_generator'],
-      scripts=['scripts/generate-schema'],
-      python_requires='~=3.5')
+      python_requires='~=3.5',
+      entry_points={
+          'console_scripts': [
+            'generate-schema = bigquery_schema_generator.generate_schema:main'
+        ]
+      }
+)

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -81,6 +81,7 @@ class TestSchemaGenerator(unittest.TestCase):
     def test_date_matcher_invalid(self):
         self.assertFalse(SchemaGenerator.DATE_MATCHER.match('17-05-22'))
         self.assertFalse(SchemaGenerator.DATE_MATCHER.match('2017-111-22'))
+        self.assertFalse(SchemaGenerator.DATE_MATCHER.match('1988-00-00'))
 
     def test_time_matcher_valid(self):
         self.assertTrue(SchemaGenerator.TIME_MATCHER.match('12:33:01'))

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -477,3 +477,82 @@ SCHEMA
   }
 ]
 END
+
+# QINTEGER, QFLOAT, QBOOLEAN
+DATA
+{ "qi" : "1", "qf": "1", "qb": "true" }
+{ "qi" : "2", "qf": "1.1", "qb": "True" }
+{ "qi" : "3", "qf": "2", "qb": "false" }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qi",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qf",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qb",
+    "type": "BOOLEAN"
+  }
+]
+END
+
+# From STRING to [QINTEGER, QFLOAT, QBOOLEAN] = STRING
+DATA
+{ "qi" : "foo", "qf": "bar", "qb": "foo2" }
+{ "qi" : "2", "qf": "1.1", "qb": "True" }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qi",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qf",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qb",
+    "type": "STRING"
+  }
+]
+END
+
+# QINTEGER -> QFLOAT -> STRING
+DATA
+{ "qn" : "1" }
+{ "qn" : "1.1" }
+{ "qn" : "test" }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qn",
+    "type": "STRING"
+  }
+]
+END
+
+# QBOOLEAN -> STRING
+DATA
+{ "qb" : "true" }
+{ "qb" : "False" }
+{ "qb" : "test" }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qb",
+    "type": "STRING"
+  }
+]
+END


### PR DESCRIPTION
## Motivation

This PR includes 3 different changes I found useful:
- If you load on BigQuery a JSON objects where INTEGERs, FLOATs and BOOLEANs are _stringified_ (`"1"` instead of `1`), BigQuery will detect the real type of the fields and mark them as INTEGER, FLOAT and BOOLEAN in the autodetected schema. bigquery-schema-generation doesn't support this type of autodetection and marks all the stringified fields as STRINGs. This PR enhances the infer mechanism to detect _stringified_ fields.
- BigQuery performs additional checks on the DATEs field not performed by bigquery-schema-generation. This means that some times load operation files because some of the dates are invalid example: `1988-00-00`. This PR improves the regex for DATEs detection.
- The current generate-schema script uses a python3 without any PATH. This is incompatibile with venv. This PR change the script install mechanism to use the _console_scripts_ entrypoint feature of setuptools (https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html)

## Modifications

- Added 3 new string types called `QINTEGER`, `QFLOAT`, `QBOOLEAN` to represent integers, float and booleans detected inside STRINGs.
- Changed the DATE regex to make it more strict
- Changed setup.py and added a console_scripts keyword in the setup call to automatically generate the generate-schema script. Removed the old script.

## Result

- _stringified_ fields are now supported
- only proper DATEs are used as DATEs :-)
- generate-schema script is automatically generated by setuptools and references the right python binary

## Note
I know it's not good form including 3 different changes in the same PR. Let me know if you want me to split them over 3 different PRs.