### PR TITLE
Fix negative number support in Q REs and adds unit tests

### DIFF
--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -55,8 +55,8 @@ class SchemaGenerator:
     # Detect a TIME field of the form [H]H:[M]M:[S]S[.DDDDDD]
     TIME_MATCHER = re.compile(r'^\d{1,2}:\d{1,2}:\d{1,2}(\.\d{1,6})?$')
 
-    INTEGER_MATCHER = re.compile(r'[-]?^\d+$')
-    FLOAT_MATCHER = re.compile(r'[-]?^\d+\.\d+$')
+    INTEGER_MATCHER = re.compile(r'^[-]?\d+$')
+    FLOAT_MATCHER = re.compile(r'^[-]?\d+\.\d+$')
 
     def __init__(self,
                  keep_nulls=False,

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -104,10 +104,15 @@ class TestSchemaGenerator(unittest.TestCase):
         self.assertEqual('STRING', generator.infer_value_type('abc'))
         self.assertEqual('BOOLEAN', generator.infer_value_type(True))
         self.assertEqual('QBOOLEAN', generator.infer_value_type('True'))
+        self.assertEqual('QBOOLEAN', generator.infer_value_type('False'))
+        self.assertEqual('QBOOLEAN', generator.infer_value_type('true'))
+        self.assertEqual('QBOOLEAN', generator.infer_value_type('false'))
         self.assertEqual('INTEGER', generator.infer_value_type(1))
         self.assertEqual('QINTEGER', generator.infer_value_type('2'))
+        self.assertEqual('QINTEGER', generator.infer_value_type('-1000'))
         self.assertEqual('FLOAT', generator.infer_value_type(2.0))
         self.assertEqual('QFLOAT', generator.infer_value_type('3.0'))
+        self.assertEqual('QFLOAT', generator.infer_value_type('-5.4'))
         self.assertEqual('RECORD', generator.infer_value_type({
             'a': 1,
             'b': 2


### PR DESCRIPTION
- QINTEGER and QFLOAT now correctly support negative numbers (verified on bq)
- Adds unit tests for negative number and lower case booleans

Signed-off-by: Luigi Mori <l@isidora.org>