### PR TITLE
0.3: support quoted values of BOOLEAN, INTEGER and FLOAT types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+* 0.3 (2018-12-17)
+    * Tighten TIMESTAMP and DATE validation (thanks jtschichold@).
+    * Inspect the internals of STRING values to infer BOOLEAN, INTEGER or FLOAT
+      types (thanks jtschichold@).
+    * Handle conversion of these string types when mixed with their non-quoted
+      equivalents, matching the conversion logic followed by 'bq load'.
 * 0.2.1 (2018-07-18)
     * Add `anonymizer.py` script to create anonymized data files for
       benchmarking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,31 @@
 # Changelog
 
 * 0.2.1 (2018-07-18)
-  * Add `anonymizer.py` script to create anonymized data files for benchmarking.
-  * Add benchmark numbers to README.md.
-  * Add `DEVELOPER.md` file to record how to upload to PyPI.
-  * Fix some minor warnings from pylint3.
+    * Add `anonymizer.py` script to create anonymized data files for
+      benchmarking.
+    * Add benchmark numbers to README.md.
+    * Add `DEVELOPER.md` file to record how to upload to PyPI.
+    * Fix some minor warnings from pylint3.
 * 0.2.0 (2018-02-10)
-  * Add support for `DATE` and `TIME` types.
-  * Update type conversion rules to be more compatible with **bq load**.
-    * Allow `DATE`, `TIME` and `TIMESTAMP` to gracefully degrade to `STRING`.
-    * Allow type conversions of elements within arrays
-      (e.g. array of `INTEGER` and `FLOAT`, or array of mixed `DATE`, `TIME`, or
-      `TIMESTAMP` elements).
-    * Better detection of invalid values (e.g. arrays of arrays).
+    * Add support for `DATE` and `TIME` types.
+    * Update type conversion rules to be more compatible with **bq load**.
+        * Allow `DATE`, `TIME` and `TIMESTAMP` to gracefully degrade to
+          `STRING`.
+        * Allow type conversions of elements within arrays
+          (e.g. array of `INTEGER` and `FLOAT`, or array of mixed `DATE`,
+          `TIME`, or `TIMESTAMP` elements).
+        * Better detection of invalid values (e.g. arrays of arrays).
 * 0.1.6 (2018-01-26)
-  * Pass along command line arguments to `generate-schema`.
+    * Pass along command line arguments to `generate-schema`.
 * 0.1.5 (2018-01-25)
-  * Updated installation instructions for MacOS.
+    * Updated installation instructions for MacOS.
 * 0.1.4 (2018-01-23)
-  * Attempt #3 to fix exception during pip3 install.
+    * Attempt #3 to fix exception during pip3 install.
 * 0.1.3 (2018-01-23)
-  * Attempt #2 to fix exception during pip3 install.
+    * Attempt #2 to fix exception during pip3 install.
 * 0.1.2 (2018-01-23)
-  * Attemp to fix exception during pip3 install. Didn't work. Pulled.
+    * Attemp to fix exception during pip3 install. Didn't work. Pulled.
 * 0.1.1 (2018-01-03)
-  * Install `generate-schema` script in `/usr/local/bin`
+    * Install `generate-schema` script in `/usr/local/bin`
 * 0.1 (2018-01-02)
-  * Iniitial release to PyPI.
+    * Iniitial release to PyPI.

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ compatibility rules implemented by **bq load**:
       upgraded to a `FLOAT`
     * the reverse does not happen, once a field is a `FLOAT`, it will remain a
       `FLOAT`
-* conflicting `TIME`, `DATE`, `TIMESTAMP` types downgrades to `STRING`
+* conflicting `TIME`, `DATE`, `TIMESTAMP` types upgrades to `STRING`
     * if a field is determined to have one type of "time" in one record, then
       subsequently a different "time" type, then the field will be assigned a
       `STRING` type

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ This is essentially what the `generate-schema` command does.
 
 **3) Python script**
 
-If you retrieved this code from its [GitHub
-repository](https://github.com/bxparks/bigquery-schema-generator), then you can invoke
-the Python script directly:
+If you retrieved this code from its
+[GitHub repository](https://github.com/bxparks/bigquery-schema-generator),
+then you can invoke the Python script directly:
 ```
 $ ./generate_schema.py < file.data.json > file.schema.json
 ```
@@ -121,21 +121,33 @@ $ ./generate_schema.py < file.data.json > file.schema.json
 The resulting schema file can be given to the **bq load** command using the
 `--schema` flag:
 ```
+
 $ bq load --source_format NEWLINE_DELIMITED_JSON \
         --ignore_unknown_values \
         --schema file.schema.json \
         mydataset.mytable \
         file.data.json
 ```
-
 where `mydataset.mytable` is the target table in BigQuery.
 
-A useful flag for **bq load** is `--ignore_unknown_values`, which causes **bq load**
-to ignore fields in the input data which are not defined in the schema. When
-`generate_schema.py` detects an inconsistency in the definition of a particular
-field in the input data, it removes the field from the schema definition.
-Without the `--ignore_unknown_values`, the **bq load** fails when the
-inconsistent data record is read.
+For debugging purposes, here is the equivalent `bq load` command using schema
+autodetection:
+
+```
+$ bq load --source_format NEWLINE_DELIMITED_JSON \
+    --ignore_unknown_values \
+    --autodetect
+    mydataset.mytable \
+    file.data.json
+```
+
+A useful flag for `bq load` is `--ignore_unknown_values`, which causes `bq
+load` to ignore fields in the input data which are not defined in the schema.
+When `generate_schema.py` detects an inconsistency in the definition of a
+particular field in the input data, it removes the field from the schema
+definition. Without the `--ignore_unknown_values`, the `bq load` fails when
+the inconsistent data record is read. Another useful flag during development and
+debugging is `--replace` which replaces any existing BigQuery table.
 
 After the BigQuery table is loaded, the schema can be retrieved using:
 
@@ -299,6 +311,10 @@ compatibility rules implemented by **bq load**:
     * we follow the same logic as **bq load** and always infer these as
       `TIMESTAMP`
 
+The BigQuery loader also looks inside strings to determine if they are actually
+INTEGER or FLOAT types instead. Luigi Mori (jtschichold@) added additional logic
+to replicate the type conversion logic used by `bq load` for these strings.
+
 ## Examples
 
 Here is an example of a single JSON data record on the STDIN (the `^D` below
@@ -392,9 +408,10 @@ tested it on:
 * Ubuntu 16.04, Python 3.5.2
 * MacOS 10.13.2, [Python 3.6.4](https://www.python.org/downloads/release/python-364/)
 
-## Author
+## Authors
 
-Created by Brian T. Park (brian@xparks.net).
+* Created by Brian T. Park (brian@xparks.net).
+* Additional type inferrence logic by Luigi Mori (jtschichold@).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ $ generate-schema --debugging_interval 50 < file.data.json > file.schema.json
 
 Instead of printing out the BigQuery schema, the `--debugging_map` prints out
 the bookkeeping metadata map which is used internally to keep track of the
-various fields and theirs types that were inferred using the data file. This
+various fields and their types that were inferred using the data file. This
 flag is intended to be used for debugging.
 
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Usage:
 $ generate-schema < file.data.json > file.schema.json
 ```
 
-Version: 0.2.1 (2018-07-18)
+Version: 0.3 (2018-12-17)
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -311,9 +311,11 @@ compatibility rules implemented by **bq load**:
     * we follow the same logic as **bq load** and always infer these as
       `TIMESTAMP`
 
-The BigQuery loader also looks inside strings to determine if they are actually
-INTEGER or FLOAT types instead. Luigi Mori (jtschichold@) added additional logic
-to replicate the type conversion logic used by `bq load` for these strings.
+The BigQuery loader looks inside string values to determine if they are actually
+BOOLEAN, INTEGER or FLOAT types instead. In other words, `"True"` is considered
+a BOOLEAN type, `"1"` is considered an INTEGER type, and `"2.1"` is consiered a
+FLOAT type. Luigi Mori (jtschichold@) added additional logic to replicate the
+type conversion logic used by `bq load` for these strings.
 
 ## Examples
 
@@ -403,6 +405,7 @@ took 77s on a Dell Precision M4700 laptop with an Intel Core i7-3840QM CPU @
 This project was initially developed on Ubuntu 17.04 using Python 3.5.3. I have
 tested it on:
 
+* Ubuntu 18.04, Python 3.6.7
 * Ubuntu 17.10, Python 3.6.3
 * Ubuntu 17.04, Python 3.5.3
 * Ubuntu 16.04, Python 3.5.2

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -55,8 +55,8 @@ class SchemaGenerator:
     # Detect a TIME field of the form [H]H:[M]M:[S]S[.DDDDDD]
     TIME_MATCHER = re.compile(r'^\d{1,2}:\d{1,2}:\d{1,2}(\.\d{1,6})?$')
 
-    INTEGER_MATCHER = re.compile(r'[-]?^\d+$')
-    FLOAT_MATCHER = re.compile(r'[-]?^\d+\.\d+$')
+    INTEGER_MATCHER = re.compile(r'^[-]?\d+$')
+    FLOAT_MATCHER = re.compile(r'^[-]?\d+\.\d+$')
 
     def __init__(self,
                  keep_nulls=False,

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -50,7 +50,8 @@ class SchemaGenerator:
         r'(([+-]\d{1,2}(:\d{1,2})?)|Z)?$')
 
     # Detect a DATE field of the form YYYY-[M]M-[D]D.
-    DATE_MATCHER = re.compile(r'^\d{4}-(?:[1-9]|0[1-9]|1[012])-(?:[1-9]|0[1-9]|[12][0-9]|3[01])$')
+    DATE_MATCHER = re.compile(
+        r'^\d{4}-(?:[1-9]|0[1-9]|1[012])-(?:[1-9]|0[1-9]|[12][0-9]|3[01])$')
 
     # Detect a TIME field of the form [H]H:[M]M:[S]S[.DDDDDD]
     TIME_MATCHER = re.compile(r'^\d{1,2}:\d{1,2}:\d{1,2}(\.\d{1,6})?$')
@@ -139,8 +140,8 @@ class SchemaGenerator:
             schema_entry = schema_map.get(key)
             try:
                 new_schema_entry = self.get_schema_entry(key, value)
-                merged_schema_entry = self.merge_schema_entry(schema_entry,
-                                                              new_schema_entry)
+                merged_schema_entry = self.merge_schema_entry(
+                    schema_entry, new_schema_entry)
             except Exception as e:
                 self.log_error(str(e))
                 continue
@@ -203,8 +204,8 @@ class SchemaGenerator:
             elif old_mode == 'REPEATED' and new_mode == 'NULLABLE':
                 # TODO: Maybe remove this warning output. It was helpful during
                 # development, but maybe it's just natural.
-                self.log_error('Leaving schema for "%s" as REPEATED RECORD' %
-                               old_name)
+                self.log_error(
+                    'Leaving schema for "%s" as REPEATED RECORD' % old_name)
 
             # RECORD type needs a recursive merging of sub-fields. We merge into
             # the 'old_schema_entry' which assumes that the 'old_schema_entry'
@@ -244,6 +245,7 @@ class SchemaGenerator:
         """
         value_mode, value_type = self.infer_bigquery_type(value)
 
+        # yapf: disable
         if value_type == 'RECORD':
             # recursively figure out the RECORD
             fields = OrderedDict()
@@ -288,6 +290,7 @@ class SchemaGenerator:
                                             ('name', key),
                                             ('type', value_type),
                                         ]))])
+        # yapf: enable
         return schema_entry
 
     def infer_bigquery_type(self, node_value):
@@ -304,8 +307,8 @@ class SchemaGenerator:
         array_type = self.infer_array_type(node_value)
         if not array_type:
             raise Exception(
-                "All array elements must be the same compatible type: %s"
-                % node_value)
+                "All array elements must be the same compatible type: %s" %
+                node_value)
 
         # Disallow array of special types (with '__' not supported).
         # EXCEPTION: allow (REPEATED __empty_record) ([{}]) because it is
@@ -331,11 +334,11 @@ class SchemaGenerator:
             elif self.TIME_MATCHER.match(value):
                 return 'TIME'
             elif self.INTEGER_MATCHER.match(value):
-                return 'QINTEGER' # quoted integer
+                return 'QINTEGER'  # quoted integer
             elif self.FLOAT_MATCHER.match(value):
-                return 'QFLOAT' # quoted float
+                return 'QFLOAT'  # quoted float
             elif value.lower() in ['true', 'false']:
-                return 'QBOOLEAN' # quoted boolean
+                return 'QBOOLEAN'  # quoted boolean
             else:
                 return 'STRING'
         # Python 'bool' is a subclass of 'int' so we must check it first
@@ -485,8 +488,9 @@ def convert_type(atype, btype):
 def is_string_type(thetype):
     """Returns true if the type is one of: STRING, TIMESTAMP, DATE, or
     TIME."""
-    return thetype in ['STRING', 'TIMESTAMP', 'DATE', 'TIME',
-        'QINTEGER', 'QFLOAT', 'QBOOLEAN']
+    return thetype in [
+        'STRING', 'TIMESTAMP', 'DATE', 'TIME', 'QINTEGER', 'QFLOAT', 'QBOOLEAN'
+    ]
 
 
 def flatten_schema_map(schema_map, keep_nulls=False):
@@ -496,8 +500,8 @@ def flatten_schema_map(schema_map, keep_nulls=False):
     data.
     """
     if not isinstance(schema_map, dict):
-        raise Exception("Unexpected type '%s' for schema_map" %
-                        type(schema_map))
+        raise Exception(
+            "Unexpected type '%s' for schema_map" % type(schema_map))
 
     # Build the BigQuery schema from the internal 'schema_map'.
     schema = []
@@ -575,7 +579,8 @@ def main():
         default=1000)
     parser.add_argument(
         '--debugging_map',
-        help='Print the metadata schema_map instead of the schema for debugging',
+        help=
+        'Print the metadata schema_map instead of the schema for debugging',
         action="store_true")
     args = parser.parse_args()
 

--- a/scripts/generate-schema
+++ b/scripts/generate-schema
@@ -1,1 +1,0 @@
-python3 -m bigquery_schema_generator.generate_schema "$@"

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,10 @@ setup(name='bigquery-schema-generator',
       author_email='brian@xparks.net',
       license='Apache 2.0',
       packages=['bigquery_schema_generator'],
-      scripts=['scripts/generate-schema'],
-      python_requires='~=3.5')
+      python_requires='~=3.5',
+      entry_points={
+          'console_scripts': [
+            'generate-schema = bigquery_schema_generator.generate_schema:main'
+        ]
+      }
+)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except:
         long_description = 'BigQuery schema generator.'
 
 setup(name='bigquery-schema-generator',
-      version='0.2.1',
+      version='0.3',
       description='BigQuery schema generator',
       long_description=long_description,
       url='https://github.com/bxparks/bigquery-schema-generator',

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -104,10 +104,15 @@ class TestSchemaGenerator(unittest.TestCase):
         self.assertEqual('STRING', generator.infer_value_type('abc'))
         self.assertEqual('BOOLEAN', generator.infer_value_type(True))
         self.assertEqual('QBOOLEAN', generator.infer_value_type('True'))
+        self.assertEqual('QBOOLEAN', generator.infer_value_type('False'))
+        self.assertEqual('QBOOLEAN', generator.infer_value_type('true'))
+        self.assertEqual('QBOOLEAN', generator.infer_value_type('false'))
         self.assertEqual('INTEGER', generator.infer_value_type(1))
         self.assertEqual('QINTEGER', generator.infer_value_type('2'))
+        self.assertEqual('QINTEGER', generator.infer_value_type('-1000'))
         self.assertEqual('FLOAT', generator.infer_value_type(2.0))
         self.assertEqual('QFLOAT', generator.infer_value_type('3.0'))
+        self.assertEqual('QFLOAT', generator.infer_value_type('-5.4'))
         self.assertEqual('RECORD', generator.infer_value_type({
             'a': 1,
             'b': 2

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -195,8 +195,9 @@ class TestSchemaGenerator(unittest.TestCase):
         self.assertEqual('FLOAT', generator.infer_array_type([1.0, 2.0]))
         self.assertEqual('BOOLEAN', generator.infer_array_type([True, False]))
         self.assertEqual('STRING', generator.infer_array_type(['a', 'b']))
-        self.assertEqual(
-            'DATE', generator.infer_array_type(['2018-02-09', '2018-02-10']))
+        self.assertEqual('DATE',
+                         generator.infer_array_type(
+                             ['2018-02-09', '2018-02-10']))
         self.assertEqual('TIME',
                          generator.infer_array_type(['10:44:00', '10:44:01']))
         self.assertEqual('TIMESTAMP',
@@ -210,8 +211,9 @@ class TestSchemaGenerator(unittest.TestCase):
         self.assertEqual('__empty_array__', generator.infer_array_type([[]]))
 
         # Mixed TIME, DATE, TIMESTAMP converts to STRING
-        self.assertEqual(
-            'STRING', generator.infer_array_type(['2018-02-09', '10:44:00']))
+        self.assertEqual('STRING',
+                         generator.infer_array_type(['2018-02-09',
+                                                     '10:44:00']))
         self.assertEqual('STRING',
                          generator.infer_array_type(
                              ['2018-02-09T11:00:00', '10:44:00']))
@@ -328,6 +330,7 @@ class TestSchemaGenerator(unittest.TestCase):
         self.assertTrue(is_string_type('TIME'))
 
     def test_sort_schema(self):
+        # yapf: disable
         unsorted = [{
             "mode": "REPEATED",
             "name": "a",
@@ -347,7 +350,6 @@ class TestSchemaGenerator(unittest.TestCase):
             "type": "STRING"
         }]
 
-        # yapf: disable
         expected = [
             OrderedDict([
                 ("mode", "REPEATED"),

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -81,6 +81,7 @@ class TestSchemaGenerator(unittest.TestCase):
     def test_date_matcher_invalid(self):
         self.assertFalse(SchemaGenerator.DATE_MATCHER.match('17-05-22'))
         self.assertFalse(SchemaGenerator.DATE_MATCHER.match('2017-111-22'))
+        self.assertFalse(SchemaGenerator.DATE_MATCHER.match('1988-00-00'))
 
     def test_time_matcher_valid(self):
         self.assertTrue(SchemaGenerator.TIME_MATCHER.match('12:33:01'))
@@ -102,8 +103,11 @@ class TestSchemaGenerator(unittest.TestCase):
                          generator.infer_value_type('2018-02-08T12:34:56'))
         self.assertEqual('STRING', generator.infer_value_type('abc'))
         self.assertEqual('BOOLEAN', generator.infer_value_type(True))
+        self.assertEqual('QBOOLEAN', generator.infer_value_type('True'))
         self.assertEqual('INTEGER', generator.infer_value_type(1))
+        self.assertEqual('QINTEGER', generator.infer_value_type('2'))
         self.assertEqual('FLOAT', generator.infer_value_type(2.0))
+        self.assertEqual('QFLOAT', generator.infer_value_type('3.0'))
         self.assertEqual('RECORD', generator.infer_value_type({
             'a': 1,
             'b': 2
@@ -235,16 +239,64 @@ class TestSchemaGenerator(unittest.TestCase):
 
     def test_convert_type(self):
         # no conversion needed
+        self.assertEqual('BOOLEAN', convert_type('BOOLEAN', 'BOOLEAN'))
         self.assertEqual('INTEGER', convert_type('INTEGER', 'INTEGER'))
         self.assertEqual('FLOAT', convert_type('FLOAT', 'FLOAT'))
         self.assertEqual('STRING', convert_type('STRING', 'STRING'))
-        self.assertEqual('BOOLEAN', convert_type('BOOLEAN', 'BOOLEAN'))
         self.assertEqual('DATE', convert_type('DATE', 'DATE'))
         self.assertEqual('RECORD', convert_type('RECORD', 'RECORD'))
 
-        # conversions
+        # quoted and unquoted versions of the same type
+        self.assertEqual('BOOLEAN', convert_type('BOOLEAN', 'QBOOLEAN'))
+        self.assertEqual('BOOLEAN', convert_type('QBOOLEAN', 'BOOLEAN'))
+        self.assertEqual('INTEGER', convert_type('INTEGER', 'QINTEGER'))
+        self.assertEqual('INTEGER', convert_type('QINTEGER', 'INTEGER'))
+        self.assertEqual('FLOAT', convert_type('FLOAT', 'QFLOAT'))
+        self.assertEqual('FLOAT', convert_type('QFLOAT', 'FLOAT'))
+
+        # [Q]INTEGER and [Q]FLOAT conversions
         self.assertEqual('FLOAT', convert_type('INTEGER', 'FLOAT'))
+        self.assertEqual('FLOAT', convert_type('INTEGER', 'QFLOAT'))
+        self.assertEqual('FLOAT', convert_type('QINTEGER', 'FLOAT'))
+        self.assertEqual('QFLOAT', convert_type('QINTEGER', 'QFLOAT'))
         self.assertEqual('FLOAT', convert_type('FLOAT', 'INTEGER'))
+        self.assertEqual('FLOAT', convert_type('FLOAT', 'QINTEGER'))
+        self.assertEqual('FLOAT', convert_type('QFLOAT', 'INTEGER'))
+        self.assertEqual('QFLOAT', convert_type('QFLOAT', 'QINTEGER'))
+
+        # quoted and STRING conversions
+        self.assertEqual('STRING', convert_type('STRING', 'QBOOLEAN'))
+        self.assertEqual('STRING', convert_type('STRING', 'QINTEGER'))
+        self.assertEqual('STRING', convert_type('STRING', 'QFLOAT'))
+        self.assertEqual('STRING', convert_type('QBOOLEAN', 'STRING'))
+        self.assertEqual('STRING', convert_type('QINTEGER', 'STRING'))
+        self.assertEqual('STRING', convert_type('QFLOAT', 'STRING'))
+
+        # quoted and DATE conversions
+        self.assertEqual('STRING', convert_type('DATE', 'QBOOLEAN'))
+        self.assertEqual('STRING', convert_type('DATE', 'QINTEGER'))
+        self.assertEqual('STRING', convert_type('DATE', 'QFLOAT'))
+        self.assertEqual('STRING', convert_type('QBOOLEAN', 'DATE'))
+        self.assertEqual('STRING', convert_type('QINTEGER', 'DATE'))
+        self.assertEqual('STRING', convert_type('QFLOAT', 'DATE'))
+
+        # quoted and TIME conversions
+        self.assertEqual('STRING', convert_type('TIME', 'QBOOLEAN'))
+        self.assertEqual('STRING', convert_type('TIME', 'QINTEGER'))
+        self.assertEqual('STRING', convert_type('TIME', 'QFLOAT'))
+        self.assertEqual('STRING', convert_type('QBOOLEAN', 'TIME'))
+        self.assertEqual('STRING', convert_type('QINTEGER', 'TIME'))
+        self.assertEqual('STRING', convert_type('QFLOAT', 'TIME'))
+
+        # quoted and TIMESTAMP conversions
+        self.assertEqual('STRING', convert_type('TIMESTAMP', 'QBOOLEAN'))
+        self.assertEqual('STRING', convert_type('TIMESTAMP', 'QINTEGER'))
+        self.assertEqual('STRING', convert_type('TIMESTAMP', 'QFLOAT'))
+        self.assertEqual('STRING', convert_type('QBOOLEAN', 'TIMESTAMP'))
+        self.assertEqual('STRING', convert_type('QINTEGER', 'TIMESTAMP'))
+        self.assertEqual('STRING', convert_type('QFLOAT', 'TIMESTAMP'))
+
+        # DATE, TIME, and TIMESTAMP conversions
         self.assertEqual('STRING', convert_type('DATE', 'TIME'))
         self.assertEqual('STRING', convert_type('DATE', 'TIMESTAMP'))
         self.assertEqual('STRING', convert_type('DATE', 'STRING'))
@@ -254,6 +306,11 @@ class TestSchemaGenerator(unittest.TestCase):
 
         # no conversion possible
         self.assertEqual(None, convert_type('INTEGER', 'BOOLEAN'))
+        self.assertEqual(None, convert_type('QINTEGER', 'BOOLEAN'))
+        self.assertEqual(None, convert_type('INTEGER', 'QBOOLEAN'))
+        self.assertEqual(None, convert_type('FLOAT', 'BOOLEAN'))
+        self.assertEqual(None, convert_type('QFLOAT', 'BOOLEAN'))
+        self.assertEqual(None, convert_type('FLOAT', 'QBOOLEAN'))
         self.assertEqual(None, convert_type('FLOAT', 'STRING'))
         self.assertEqual(None, convert_type('STRING', 'BOOLEAN'))
         self.assertEqual(None, convert_type('BOOLEAN', 'DATE'))

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -527,7 +527,7 @@ SCHEMA
 ]
 END
 
-# mixed [Q]INTEGER, [Q]FLOAT
+# [Q]INTEGER + [Q]FLOAT -> FLOAT
 DATA
 { "qf_i" : "1.0", "qi_f": "2" }
 { "qf_i" : 1.1, "qi_f": 2.1 }
@@ -546,7 +546,7 @@ SCHEMA
 ]
 END
 
-# From STRING to [QINTEGER, QFLOAT, QBOOLEAN] = STRING
+# STRING + [QINTEGER, QFLOAT, QBOOLEAN] -> STRING
 DATA
 { "qi" : "foo", "qf": "bar", "qb": "foo2" }
 { "qi" : "2", "qf": "1.1", "qb": "True" }
@@ -623,7 +623,7 @@ SCHEMA
 ]
 END
 
-# DATE, TIME, DATETIME + [QINTEGER, QFLOAT, QBOOLEAN] => STRING
+# DATE, TIME, DATETIME + [QINTEGER, QFLOAT, QBOOLEAN] -> STRING
 DATA
 { "qd" : "2018-12-07", "qt": "21:52:00", "qdt": "2018-12-07T21:52:00-08:00" }
 { "qd" : "1", "qt": "1.1", "qdt": "true" }

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -477,3 +477,173 @@ SCHEMA
   }
 ]
 END
+
+# QINTEGER, QFLOAT, QBOOLEAN
+DATA
+{ "qi" : "1", "qf": "1.0", "qb": "true" }
+{ "qi" : "2", "qf": "1.1", "qb": "True" }
+{ "qi" : "3", "qf": "2.0", "qb": "false" }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qi",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qf",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qb",
+    "type": "BOOLEAN"
+  }
+]
+END
+
+# QINTEGER, QFLOAT, QBOOLEAN -> INTEGER, FLOAT, BOOLEAN
+DATA
+{ "qi" : "1", "qf": "1.0", "qb": "true" }
+{ "qi" : 2, "qf": 2.0, "qb": false }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qi",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qf",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qb",
+    "type": "BOOLEAN"
+  }
+]
+END
+
+# mixed [Q]INTEGER, [Q]FLOAT
+DATA
+{ "qf_i" : "1.0", "qi_f": "2" }
+{ "qf_i" : 1.1, "qi_f": 2.1 }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qf_i",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qi_f",
+    "type": "FLOAT"
+  }
+]
+END
+
+# From STRING to [QINTEGER, QFLOAT, QBOOLEAN] = STRING
+DATA
+{ "qi" : "foo", "qf": "bar", "qb": "foo2" }
+{ "qi" : "2", "qf": "1.1", "qb": "True" }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qi",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qf",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qb",
+    "type": "STRING"
+  }
+]
+END
+
+# QINTEGER -> QFLOAT -> STRING
+DATA
+{ "qn" : "1" }
+{ "qn" : "1.1" }
+{ "qn" : "test" }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qn",
+    "type": "STRING"
+  }
+]
+END
+
+# QBOOLEAN -> STRING
+DATA
+{ "qb" : "true" }
+{ "qb" : "False" }
+{ "qb" : "test" }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qb",
+    "type": "STRING"
+  }
+]
+END
+
+# DATE, TIME, DATETIME
+DATA
+{ "qd" : "2018-12-07", "qt": "21:52:00", "qdt": "2018-12-07T21:52:00-08:00" }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qd",
+    "type": "DATE"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qt",
+    "type": "TIME"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qdt",
+    "type": "TIMESTAMP"
+  }
+]
+END
+
+# DATE, TIME, DATETIME + [QINTEGER, QFLOAT, QBOOLEAN] => STRING
+DATA
+{ "qd" : "2018-12-07", "qt": "21:52:00", "qdt": "2018-12-07T21:52:00-08:00" }
+{ "qd" : "1", "qt": "1.1", "qdt": "true" }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qd",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qt",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qdt",
+    "type": "STRING"
+  }
+]
+END
+


### PR DESCRIPTION
* 0.3 (2018-12-17)
    * Tighten TIMESTAMP and DATE validation (thanks jtschichold@).
    * Inspect the internals of STRING values to infer BOOLEAN, INTEGER or FLOAT
      types (thanks jtschichold@).
    * Handle conversion of these string types when mixed with their non-quoted
      equivalents, matching the conversion logic followed by 'bq load'.
