### PR TITLE
0.3.1 - support integers that overflow 64 bits; support 'UTC' suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* Unreleased
+    * Integers that overflow signed 64-bits are inferred to be `FLOAT` for
+      consistency with `bq load`.
 * 0.3 (2018-12-17)
     * Tighten TIMESTAMP and DATE validation (thanks jtschichold@).
     * Inspect the internals of STRING values to infer BOOLEAN, INTEGER or FLOAT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-* Unreleased
-    * Integers that overflow signed 64-bits are inferred to be `FLOAT` for
-      consistency with `bq load`.
-    * Support 'UTC' suffix in TIMESTAMP fields, in addition to 'Z'.
+* 0.3.1 (2019-01-18)
+    * Infer integers that overflow signed 64-bits to be `FLOAT` for
+      consistency with `bq load`. (Fixes #18)
+    * Support 'UTC' suffix in TIMESTAMP fields, in addition to 'Z'. (Fixes #19)
 * 0.3 (2018-12-17)
     * Tighten TIMESTAMP and DATE validation (thanks jtschichold@).
     * Inspect the internals of STRING values to infer BOOLEAN, INTEGER or FLOAT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     * Integers that overflow signed 64-bits are inferred to be `FLOAT` for
       consistency with `bq load`.
+    * Support 'UTC' suffix in TIMESTAMP fields, in addition to 'Z'.
 * 0.3 (2018-12-17)
     * Tighten TIMESTAMP and DATE validation (thanks jtschichold@).
     * Inspect the internals of STRING values to infer BOOLEAN, INTEGER or FLOAT

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ autodetection:
 ```
 $ bq load --source_format NEWLINE_DELIMITED_JSON \
     --ignore_unknown_values \
-    --autodetect
+    --autodetect \
     mydataset.mytable \
     file.data.json
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Usage:
 $ generate-schema < file.data.json > file.schema.json
 ```
 
-Version: 0.3 (2018-12-17)
+Version: 0.3.1 (2019-01-18)
 
 ## Background
 
@@ -295,7 +295,7 @@ The difference from `bq load` is that the `[time zone]` component can be only
 The suffix `UTC` is not standard ISO 8601 nor
 [documented by Google](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#time-zones)
 but the `UTC` suffix is used by `bq extract` and the web interface. (See
-[Issue 19](https://github.com/bxparks/bigquery-schema-generator/issues/19).
+[Issue 19](https://github.com/bxparks/bigquery-schema-generator/issues/19).)
 
 Timezone names from the [tz database](http://www.iana.org/time-zones) (e.g.
 "America/Los_Angeles") are _not_ supported by `generate-schema`.
@@ -333,10 +333,10 @@ compatibility rules implemented by **bq load**:
     * we follow the same logic as **bq load** and always infer these as
       `TIMESTAMP`
 * `BOOLEAN`, `INTEGER`, and `FLOAT` can appear inside quoted strings
-  * In other words, `"True"` is considered a BOOLEAN type, `"1"` is considered
-    an INTEGER type, and `"2.1"` is considered a FLOAT type. Luigi Mori
-    (jtschichold@) added additional logic to replicate the type conversion
-    logic used by `bq load` for these strings.
+  * In other words, `"true"` (or `"True"` or `"false"`, etc) is considered a
+    BOOLEAN type, `"1"` is considered an INTEGER type, and `"2.1"` is considered
+    a FLOAT type. Luigi Mori (jtschichold@) added additional logic to replicate
+    the type conversion logic used by `bq load` for these strings.
 * `INTEGER` values overflowing a 64-bit signed integer upgrade to `FLOAT`
     * integers greater than `2^63-1` (9223372036854775807)
     * integers less than `-2^63` (-9223372036854775808)
@@ -434,7 +434,12 @@ tested it on:
 * Ubuntu 17.10, Python 3.6.3
 * Ubuntu 17.04, Python 3.5.3
 * Ubuntu 16.04, Python 3.5.2
+* MacOS 10.14.2, [Python 3.6.4](https://www.python.org/downloads/release/python-364/)
 * MacOS 10.13.2, [Python 3.6.4](https://www.python.org/downloads/release/python-364/)
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md).
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -305,17 +305,20 @@ compatibility rules implemented by **bq load**:
 * a primitive type (`FLOAT`, `INTEGER`, `STRING`) cannot upgrade to a `REPEATED`
   primitive type
     * there's no technical reason why this cannot be allowed, but **bq load**
-      does not support it, so we follow the rule
+      does not support it, so we follow its behavior
 * a `DATETIME` field is always inferred to be a `TIMESTAMP`
     * the format of these two fields is identical (in the absence of timezone)
     * we follow the same logic as **bq load** and always infer these as
       `TIMESTAMP`
-
-The BigQuery loader looks inside string values to determine if they are actually
-BOOLEAN, INTEGER or FLOAT types instead. In other words, `"True"` is considered
-a BOOLEAN type, `"1"` is considered an INTEGER type, and `"2.1"` is consiered a
-FLOAT type. Luigi Mori (jtschichold@) added additional logic to replicate the
-type conversion logic used by `bq load` for these strings.
+* `BOOLEAN`, `INTEGER`, and `FLOAT` can appear inside quoted strings
+  * In other words, `"True"` is considered a BOOLEAN type, `"1"` is considered
+    an INTEGER type, and `"2.1"` is considered a FLOAT type. Luigi Mori
+    (jtschichold@) added additional logic to replicate the type conversion
+    logic used by `bq load` for these strings.
+* `INTEGER` values overflowing a 64-bit signed integer upgrade to `FLOAT`
+    * integers greater than `2^63-1` (9223372036854775807)
+    * integers less than `-2^63` (-9223372036854775808)
+    * (See [Issue #18](https://github.com/bxparks/bigquery-schema-generator/issues/18) for more details)
 
 ## Examples
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except:
         long_description = 'BigQuery schema generator.'
 
 setup(name='bigquery-schema-generator',
-      version='0.3',
+      version='0.3.1',
       description='BigQuery schema generator',
       long_description=long_description,
       url='https://github.com/bxparks/bigquery-schema-generator',

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,3 +43,12 @@ Ran 1 test in 0.000s
 
 OK
 ```
+
+## Running All Tests
+
+Use the
+[discovery mode](https://docs.python.org/3/library/unittest.html)
+for `unittest` which runs all tests with the `test_` prefix:
+```
+$ python3 -m unittest
+```

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -97,26 +97,58 @@ class TestSchemaGenerator(unittest.TestCase):
 
     def test_infer_value_type(self):
         generator = SchemaGenerator()
+
+        # STRING and date/time
+        self.assertEqual('STRING', generator.infer_value_type('abc'))
         self.assertEqual('TIME', generator.infer_value_type('12:34:56'))
         self.assertEqual('DATE', generator.infer_value_type('2018-02-08'))
         self.assertEqual('TIMESTAMP',
                          generator.infer_value_type('2018-02-08T12:34:56'))
-        self.assertEqual('STRING', generator.infer_value_type('abc'))
+
+        # BOOLEAN
         self.assertEqual('BOOLEAN', generator.infer_value_type(True))
         self.assertEqual('QBOOLEAN', generator.infer_value_type('True'))
         self.assertEqual('QBOOLEAN', generator.infer_value_type('False'))
         self.assertEqual('QBOOLEAN', generator.infer_value_type('true'))
         self.assertEqual('QBOOLEAN', generator.infer_value_type('false'))
+
+        # INTEGER
         self.assertEqual('INTEGER', generator.infer_value_type(1))
+        self.assertEqual('INTEGER',
+                         generator.infer_value_type(9223372036854775807))
+        self.assertEqual('INTEGER',
+                         generator.infer_value_type(-9223372036854775808))
+        self.assertEqual('FLOAT',
+                         generator.infer_value_type(9223372036854775808))
+        self.assertEqual('FLOAT',
+                         generator.infer_value_type(-9223372036854775809))
+
+        # Quoted INTEGER
         self.assertEqual('QINTEGER', generator.infer_value_type('2'))
         self.assertEqual('QINTEGER', generator.infer_value_type('-1000'))
+        self.assertEqual('QINTEGER',
+                         generator.infer_value_type('9223372036854775807'))
+        self.assertEqual('QINTEGER',
+                         generator.infer_value_type('-9223372036854775808'))
+        self.assertEqual('QFLOAT',
+                         generator.infer_value_type('9223372036854775808'))
+        self.assertEqual('QFLOAT',
+                         generator.infer_value_type('-9223372036854775809'))
+
+        # FLOAT
         self.assertEqual('FLOAT', generator.infer_value_type(2.0))
+
+        # Quoted FLOAT
         self.assertEqual('QFLOAT', generator.infer_value_type('3.0'))
         self.assertEqual('QFLOAT', generator.infer_value_type('-5.4'))
+
+        # RECORD
         self.assertEqual('RECORD', generator.infer_value_type({
             'a': 1,
             'b': 2
         }))
+
+        # Special
         self.assertEqual('__null__', generator.infer_value_type(None))
         self.assertEqual('__empty_record__', generator.infer_value_type({}))
         self.assertEqual('__empty_array__', generator.infer_value_type([]))

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -647,3 +647,46 @@ SCHEMA
 ]
 END
 
+# Integers in quoted strings that fit inside a signed 64-bit -> INTEGER
+# See https://github.com/bxparks/bigquery-schema-generator/issues/18.
+DATA
+{"name": "9223372036854775807"}
+{"name": "-9223372036854775808"}
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "INTEGER"
+  }
+]
+END
+
+# Integers in quoted strings that overflow a signed 64-bit -> FLOAT
+# See https://github.com/bxparks/bigquery-schema-generator/issues/18.
+DATA
+{"name": "9223372036854775808"}
+{"name": "-9223372036854775809"}
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "FLOAT"
+  }
+]
+END
+
+# (Overflowing integer inside quotes) + STRING -> STRING
+DATA
+{"name": "9223372036854775808"}
+{"name": "hello"}
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "STRING"
+  }
+]
+END


### PR DESCRIPTION
* 0.3.1 (2019-01-18)
    * Infer integers that overflow signed 64-bits to be `FLOAT` for
      consistency with `bq load`. (Fixes #18)
    * Support 'UTC' suffix in TIMESTAMP fields, in addition to 'Z'. (Fixes #19)