### PR TITLE
0.3.2 - add flag to force quoted values to be inferred as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+* Unreleased
+    * Add `--quoted_values_are_strings` flag to force quoted values (integers,
+      floats, booleans) to be interpreted as a `STRING`. (Thanks de-code@,
+      see #22).
 * 0.3.1 (2019-01-18)
     * Infer integers that overflow signed 64-bits to be `FLOAT` for
       consistency with `bq load`. (Fixes #18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 0.3.2 (2019-02-24)
     * Add `--quoted_values_are_strings` flag to force quoted values (integers,
       floats, booleans) to be interpreted as a `STRING`. (Thanks de-code@,
       see #22).

--- a/README.md
+++ b/README.md
@@ -242,9 +242,11 @@ INFO:root:Processed 1 lines
 #### Quoted Values Are Strings (`--quoted_values_are_strings`)
 
 By default, quoted values are inspected to determine if they can be interpreted
-as integers, floats or booleans. This is consistent with the algorithm used by
-`bq load`. However, sometimes this is not the desired behavior. This flag forces
-the `generate-schema` script to always interpret quoted values as a `STRING`.
+as `DATE`, `TIME`, `TIMESTAMP`, `BOOLEAN`, `INTEGER` or `FLOAT`. This is
+consistent with the algorithm used by `bq load`. However, for the `BOOLEAN`,
+`INTEGER`, or `FLOAT` types, it is sometimes more useful to interpret those as
+normal strings instead. This flag disables type inference for `BOOLEAN`,
+`INTEGER` and `FLOAT` types inside quoted strings.
 
 ```
 $ generate-schema
@@ -372,7 +374,7 @@ compatibility rules implemented by **bq load**:
       considered a FLOAT type. Luigi Mori (jtschichold@) added additional logic
       to replicate the type conversion logic used by `bq load` for these
       strings.
-    * This type inferrence inside quoted strings can be disabled using the
+    * This type inference inside quoted strings can be disabled using the
       `--quoted_values_are_strings` flag
     * (See [Issue #22](https://github.com/bxparks/bigquery-schema-generator/issues/22) for more details.)
 * `INTEGER` values overflowing a 64-bit signed integer upgrade to `FLOAT`
@@ -482,7 +484,9 @@ See [CHANGELOG.md](CHANGELOG.md).
 ## Authors
 
 * Created by Brian T. Park (brian@xparks.net).
-* Additional type inferrence logic by Luigi Mori (jtschichold@).
+* Additional type inference logic by Luigi Mori (jtschichold@).
+* Flag to disable type inference inside quoted strings by Daniel Ecer
+  (de-code@).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Usage:
 $ generate-schema < file.data.json > file.schema.json
 ```
 
-Version: 0.3.1 (2019-01-18)
+Version: 0.3.2 (2019-02-24)
 
 ## Background
 

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -70,10 +70,12 @@ class SchemaGenerator:
 
     def __init__(self,
                  keep_nulls=False,
+                 quoted_values_are_strings=False,
                  debugging_interval=1000,
                  debugging_map=False):
-        self.debugging_interval = debugging_interval
         self.keep_nulls = keep_nulls
+        self.quoted_values_are_strings = quoted_values_are_strings
+        self.debugging_interval = debugging_interval
         self.debugging_map = debugging_map
         self.line_number = 0
         self.error_logs = []
@@ -347,16 +349,21 @@ class SchemaGenerator:
                 return 'DATE'
             elif self.TIME_MATCHER.match(value):
                 return 'TIME'
-            elif self.INTEGER_MATCHER.match(value):
-                if int(value) < self.INTEGER_MIN_VALUE or \
-                    self.INTEGER_MAX_VALUE < int(value):
+            elif not self.quoted_values_are_strings:
+                # Implement the same type inference algorithm as 'bq load' for
+                # quoted values that look like ints, floats or bools.
+                if self.INTEGER_MATCHER.match(value):
+                    if int(value) < self.INTEGER_MIN_VALUE or \
+                        self.INTEGER_MAX_VALUE < int(value):
+                        return 'QFLOAT'  # quoted float
+                    else:
+                        return 'QINTEGER'  # quoted integer
+                elif self.FLOAT_MATCHER.match(value):
                     return 'QFLOAT'  # quoted float
+                elif value.lower() in ['true', 'false']:
+                    return 'QBOOLEAN'  # quoted boolean
                 else:
-                    return 'QINTEGER'  # quoted integer
-            elif self.FLOAT_MATCHER.match(value):
-                return 'QFLOAT'  # quoted float
-            elif value.lower() in ['true', 'false']:
-                return 'QBOOLEAN'  # quoted boolean
+                    return 'STRING'
             else:
                 return 'STRING'
         # Python 'bool' is a subclass of 'int' so we must check it first
@@ -594,6 +601,10 @@ def main():
         help='Print the schema for null values, empty arrays or empty records.',
         action="store_true")
     parser.add_argument(
+        '--quoted_values_are_strings',
+        help='Quoted values should be interpreted as strings',
+        action="store_true")
+    parser.add_argument(
         '--debugging_interval',
         help='Number of lines between heartbeat debugging messages.',
         type=int,
@@ -608,8 +619,11 @@ def main():
     # Configure logging.
     logging.basicConfig(level=logging.INFO)
 
-    generator = SchemaGenerator(args.keep_nulls, args.debugging_interval,
-                                args.debugging_map)
+    generator = SchemaGenerator(
+        keep_nulls=args.keep_nulls,
+        quoted_values_are_strings=args.quoted_values_are_strings,
+        debugging_interval=args.debugging_interval,
+        debugging_map=args.debugging_map)
     generator.run()
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except:
         long_description = 'BigQuery schema generator.'
 
 setup(name='bigquery-schema-generator',
-      version='0.3.1',
+      version='0.3.2',
       description='BigQuery schema generator',
       long_description=long_description,
       url='https://github.com/bxparks/bigquery-schema-generator',

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -162,6 +162,19 @@ class TestSchemaGenerator(unittest.TestCase):
         self.assertEqual('__empty_array__', generator.infer_value_type([]))
         self.assertEqual('__array__', generator.infer_value_type([1, 2, 3]))
 
+    def test_quoted_values_are_strings(self):
+        generator = SchemaGenerator(quoted_values_are_strings=True)
+        self.assertEqual('STRING', generator.infer_value_type('abcd'))
+
+        self.assertEqual('INTEGER', generator.infer_value_type(1))
+        self.assertEqual('STRING', generator.infer_value_type('1'))
+
+        self.assertEqual('FLOAT', generator.infer_value_type(1.0))
+        self.assertEqual('STRING', generator.infer_value_type('1.0'))
+
+        self.assertEqual('BOOLEAN', generator.infer_value_type(True))
+        self.assertEqual('STRING', generator.infer_value_type('True'))
+
     def test_infer_bigquery_type(self):
         generator = SchemaGenerator()
 
@@ -442,6 +455,7 @@ class TestFromDataFile(unittest.TestCase):
     def verify_data_chunk(self, chunk_count, chunk):
         data_flags = chunk['data_flags']
         keep_nulls = ('keep_nulls' in data_flags)
+        quoted_values_are_strings = ('quoted_values_are_strings' in data_flags)
         records = chunk['records']
         expected_errors = chunk['errors']
         expected_error_map = chunk['error_map']
@@ -450,7 +464,8 @@ class TestFromDataFile(unittest.TestCase):
         print("Test chunk %s: First record: %s" % (chunk_count, records[0]))
 
         # Generate schema.
-        generator = SchemaGenerator(keep_nulls)
+        generator = SchemaGenerator(keep_nulls=keep_nulls,
+            quoted_values_are_strings=quoted_values_are_strings)
         schema_map, error_logs = generator.deduce_schema(records)
         schema = generator.flatten_schema(schema_map)
 

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -707,3 +707,29 @@ SCHEMA
   }
 ]
 END
+
+# Quoted values are forced to be strings if --quoted_values_are_strings flag
+# given
+DATA quoted_values_are_strings
+{ "qi" : "1", "qf": "1.0", "qb": "true" }
+{ "qi" : "2", "qf": "1.1", "qb": "True" }
+{ "qi" : "3", "qf": "2.0", "qb": "false" }
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "qi",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qf",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "qb",
+    "type": "STRING"
+  }
+]
+END


### PR DESCRIPTION
* 0.3.2 (2019-02-24)
    * Add `--quoted_values_are_strings` flag to force quoted values (integers,
      floats, booleans) to be interpreted as a `STRING`. (Thanks de-code@,
      see #22).