### PR TITLE
Add support for CSV files with header in first row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 * Unreleased
+    * Support CSV input files using `--input_format` flag. Preserve
+      the ordering of fields in the schema file for CSV.
 * 0.3.2 (2019-02-24)
     * Add `--quoted_values_are_strings` flag to force quoted values (integers,
       floats, booleans) to be interpreted as a `STRING`. (Thanks de-code@,

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # BigQuery Schema Generator
 
-This script generates the BigQuery schema from the newline-delimited JSON data
-records on the STDIN. The BigQuery data importer (`bq load`) uses only the
-first 100 lines when the schema auto-detection feature is enabled. In contrast,
-this script uses all data records to generate the schema.
+This script generates the BigQuery schema from the newline-delimited data
+records on the STDIN. The records can be in JSON format or CSV format. The
+BigQuery data importer (`bq load`) uses only the first 100 lines when the schema
+auto-detection feature is enabled. In contrast, this script uses all data
+records to generate the schema.
 
 Usage:
 ```
 $ generate-schema < file.data.json > file.schema.json
+$ generate-schema --input_format csv < file.data.csv > file.schema.json
 ```
 
 Version: 0.3.2 (2019-02-24)
@@ -24,7 +26,8 @@ schema can be defined manually or the schema can be
 [auto-detected](https://cloud.google.com/bigquery/docs/schema-detect#auto-detect).
 
 When the auto-detect feature is used, the BigQuery data importer examines only
-the first 100 records of the input data. In many cases, this is sufficient
+the [first 100 records](https://cloud.google.com/bigquery/docs/schema-detect)
+of the input data. In many cases, this is sufficient
 because the data records were dumped from another database and the exact schema
 of the source table was known. However, for data extracted from a service
 (e.g. using a REST API) the record fields could have been organically added
@@ -53,11 +56,12 @@ the `sudo` coommand, and you can just type:
 $ pip3 install bigquery_schema_generator
 ```
 
-A successful install should print out the following:
+A successful install should print out something the following (the version
+number may be different):
 ```
 Collecting bigquery-schema-generator
 Installing collected packages: bigquery-schema-generator
-Successfully installed bigquery-schema-generator-0.1.4
+Successfully installed bigquery-schema-generator-0.3.2
 ```
 
 The shell script `generate-schema` is installed in the same directory as
@@ -84,8 +88,14 @@ command without typing in the full path.
 
 ## Usage
 
-The `generate_schema.py` script accepts a newline-delimited JSON data file on
-the STDIN. (CSV is not supported currently.) It scans every record in the
+The `generate_schema.py` script accepts a newline-delimited data file on
+the STDIN. JSON input format has been tested and supported robustly.
+CSV input format was added more recently (in v0.4) using the `--input_format
+csv` flag. The support is not as robust as JSON file. For example, CSV format
+supports only the comma-separator, and does not support the pipe (`|`) or tab
+(`\t`) character.
+
+Unlike `bq load`, the `generate_schema.py` script reads every record in the
 input data file to deduce the table's schema. It prints the JSON formatted
 schema file on the STDOUT. There are at least 3 ways to run this script:
 
@@ -165,8 +175,11 @@ The `generate_schema.py` script supports a handful of command line flags:
 * `--help` Prints the usage with the list of supported flags.
 * `--keep_nulls` Print the schema for null values, empty arrays or empty records.
 * `--quoted_values_are_strings` Quoted values should be interpreted as strings
-* `--debugging_interval lines` Number of lines between heartbeat debugging messages. Default 1000.
+* `--debugging_interval lines` Number of lines between heartbeat debugging
+  messages. Default 1000.
 * `--debugging_map` Print the metadata schema map for debugging purposes
+* `--input_format` Specifies the input file format ('csv' or 'json') with 'json'
+  as the default.
 
 #### Help (`--help`)
 
@@ -174,23 +187,30 @@ Print the built-in help strings:
 
 ```
 $ generate-schema --help
-usage: generate_schema.py [-h] [--keep_nulls]
-                          [--debugging_interval DEBUGGING_INTERVAL]
-                          [--debugging_map]
+usage: generate-schema [-h] [--input_format INPUT_FORMAT] [--keep_nulls]
+                       [--quoted_values_are_strings]
+                       [--debugging_interval DEBUGGING_INTERVAL]
+                       [--debugging_map]
 
-Generate BigQuery schema.
+Generate BigQuery schema from JSON or CSV file.
 
 optional arguments:
   -h, --help            show this help message and exit
+  --input_format INPUT_FORMAT
+                        Specify an alternative input format ('csv', 'json')
   --keep_nulls          Print the schema for null values, empty arrays or
-                        empty records.
+                        empty records
   --quoted_values_are_strings
                         Quoted values should be interpreted as strings
   --debugging_interval DEBUGGING_INTERVAL
-                        Number of lines between heartbeat debugging messages.
+                        Number of lines between heartbeat debugging messages
   --debugging_map       Print the metadata schema_map instead of the schema
                         for debugging
 ```
+
+#### Input Format (`--input_format`)
+
+Specifies the format of the input file, either `json` (default) or `csv`.
 
 #### Keep Nulls (`--keep_nulls`)
 

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -304,7 +304,13 @@ class SchemaGenerator:
                                             ('type', 'RECORD'),
                                         ]))])
         else:
-            schema_entry = OrderedDict([('status', 'hard'),
+            # Empty fields are returned as empty strings, and must be treated as
+            # a (soft String) to allow clobbering by subsquent non-empty fields.
+            if value == "" and self.input_format == 'csv':
+                status = 'soft'
+            else:
+                status = 'hard'
+            schema_entry = OrderedDict([('status', status),
                                         ('info', OrderedDict([
                                             ('mode', value_mode),
                                             ('name', key),

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -609,29 +609,6 @@ def flatten_schema_map(schema_map, keep_nulls=False, sorted_schema=True):
     return schema
 
 
-def sort_schema(schema):
-    """Sort the given BigQuery 'schema' and return a version that uses
-    'OrderedDict' with the same sorting rules as BigQuery.
-    """
-    if not isinstance(schema, list):
-        raise Exception('Unsupported type %s' % type(schema))
-
-    old_sorted = sorted(schema, key=lambda x: x['name'])
-    new_sorted = []
-    for old_elem in old_sorted:
-        if not isinstance(old_elem, dict):
-            raise Exception('Unsupported type %s' % type(schema))
-
-        new_elem = OrderedDict()
-        for key, value in sorted(old_elem.items()):
-            if key == 'fields':
-                new_elem[key] = sort_schema(value)
-            else:
-                new_elem[key] = value
-        new_sorted.append(new_elem)
-    return new_sorted
-
-
 def main():
     # Configure command line flags.
     parser = argparse.ArgumentParser(

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -454,9 +454,12 @@ class TestFromDataFile(unittest.TestCase):
 
     def verify_data_chunk(self, chunk_count, chunk):
         data_flags = chunk['data_flags']
-        keep_nulls = ('keep_nulls' in data_flags)
-        quoted_values_are_strings = ('quoted_values_are_strings' in data_flags)
         input_format = 'csv' if ('csv' in data_flags) else 'json'
+        if input_format == 'csv':
+            keep_nulls = True
+        else:
+            keep_nulls = ('keep_nulls' in data_flags)
+        quoted_values_are_strings = ('quoted_values_are_strings' in data_flags)
         records = chunk['records']
         expected_errors = chunk['errors']
         expected_error_map = chunk['error_map']
@@ -472,8 +475,8 @@ class TestFromDataFile(unittest.TestCase):
         schema_map, error_logs = generator.deduce_schema(records)
         schema = generator.flatten_schema(schema_map)
 
-        # Check the schema
-        expected = sort_schema(json.loads(expected_schema))
+        # Check the schema, preserving order
+        expected = json.loads(expected_schema, object_pairs_hook=OrderedDict)
         self.assertEqual(expected, schema)
 
         # Check the error messages

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -410,10 +410,7 @@ class TestFromDataFile(unittest.TestCase):
     def verify_data_chunk(self, chunk_count, chunk):
         data_flags = chunk['data_flags']
         input_format = 'csv' if ('csv' in data_flags) else 'json'
-        if input_format == 'csv':
-            keep_nulls = True
-        else:
-            keep_nulls = ('keep_nulls' in data_flags)
+        keep_nulls = ('keep_nulls' in data_flags)
         quoted_values_are_strings = ('quoted_values_are_strings' in data_flags)
         records = chunk['records']
         expected_errors = chunk['errors']
@@ -424,9 +421,9 @@ class TestFromDataFile(unittest.TestCase):
 
         # Generate schema.
         generator = SchemaGenerator(
+            input_format=input_format,
             keep_nulls=keep_nulls,
-            quoted_values_are_strings=quoted_values_are_strings,
-            input_format=input_format)
+            quoted_values_are_strings=quoted_values_are_strings)
         schema_map, error_logs = generator.deduce_schema(records)
         schema = generator.flatten_schema(schema_map)
 

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -456,6 +456,7 @@ class TestFromDataFile(unittest.TestCase):
         data_flags = chunk['data_flags']
         keep_nulls = ('keep_nulls' in data_flags)
         quoted_values_are_strings = ('quoted_values_are_strings' in data_flags)
+        input_format = 'csv' if ('csv' in data_flags) else 'json'
         records = chunk['records']
         expected_errors = chunk['errors']
         expected_error_map = chunk['error_map']
@@ -464,8 +465,10 @@ class TestFromDataFile(unittest.TestCase):
         print("Test chunk %s: First record: %s" % (chunk_count, records[0]))
 
         # Generate schema.
-        generator = SchemaGenerator(keep_nulls=keep_nulls,
-            quoted_values_are_strings=quoted_values_are_strings)
+        generator = SchemaGenerator(
+            keep_nulls=keep_nulls,
+            quoted_values_are_strings=quoted_values_are_strings,
+            input_format=input_format)
         schema_map, error_logs = generator.deduce_schema(records)
         schema = generator.flatten_schema(schema_map)
 

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -19,7 +19,6 @@ import os
 import json
 from collections import OrderedDict
 from bigquery_schema_generator.generate_schema import SchemaGenerator
-from bigquery_schema_generator.generate_schema import sort_schema
 from bigquery_schema_generator.generate_schema import is_string_type
 from bigquery_schema_generator.generate_schema import convert_type
 from data_reader import DataReader
@@ -381,50 +380,6 @@ class TestSchemaGenerator(unittest.TestCase):
         self.assertTrue(is_string_type('TIMESTAMP'))
         self.assertTrue(is_string_type('DATE'))
         self.assertTrue(is_string_type('TIME'))
-
-    def test_sort_schema(self):
-        # yapf: disable
-        unsorted = [{
-            "mode": "REPEATED",
-            "name": "a",
-            "type": "STRING"
-        }, {
-            "fields": [{
-                "mode": "NULLABLE",
-                "name": "__unknown__",
-                "type": "STRING"
-            }],
-            "mode": "NULLABLE",
-            "name": "m",
-            "type": "RECORD"
-        }, {
-            "mode": "NULLABLE",
-            "name": "s",
-            "type": "STRING"
-        }]
-
-        expected = [
-            OrderedDict([
-                ("mode", "REPEATED"),
-                ("name", "a"),
-                ("type", "STRING")]),
-            OrderedDict([
-                ("fields", [
-                    OrderedDict([
-                        ("mode", "NULLABLE"),
-                        ("name", "__unknown__"),
-                        ("type", "STRING")])
-                ]),
-                ("mode", "NULLABLE"),
-                ("name", "m"),
-                ("type", "RECORD")]),
-            OrderedDict([
-                ("mode", "NULLABLE"),
-                ("name", "s"),
-                ("type", "STRING")])
-        ]
-        # yapf: enable
-        self.assertEqual(expected, sort_schema(unsorted))
 
 
 class TestFromDataFile(unittest.TestCase):

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -761,12 +761,41 @@ SCHEMA
 ]
 END
 
+# A missing field (no comma-separator) is read as a 'null'. An empty field is
+# read as an empty string ("") but should be interpreted to be a 'null' to
+# allow subsequent non-null fields to determine the type.
+DATA csv
+name,surname,age
+John
+Michael,,
+Maria,Smith,30
+Joanna,Anders,21
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "age",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "surname",
+    "type": "STRING"
+  }
+]
+END
+
 # CSV file requiring more complex type inference
 DATA csv
 name,surname,age,is_student,registration_date,score
-John,Smith,23,true,2019-02-26 13:20:00,1
-Michael,Johnson,27,True,2019-02-26T13:21:00,2.0
-Maria,Smith,30,false,2019-02-26 13:22:00 UTC,3.1
+John
+Michael,Johnson,27,True,,2.0
+Maria,"","",false,2019-02-26 13:22:00 UTC,
 Joanna,Anders,21,"False",2019-02-26 13:23:00,4
 SCHEMA
 [

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -13,25 +13,25 @@ SCHEMA
 [
   {
     "mode": "REPEATED",
-    "type": "STRING",
-    "name": "a"
+    "name": "a",
+    "type": "STRING"
   },
   {
-    "mode": "NULLABLE",
     "fields": [
       {
         "mode": "NULLABLE",
-        "type": "STRING",
-        "name": "__unknown__"
+        "name": "__unknown__",
+        "type": "STRING"
       }
     ],
-    "type": "RECORD",
-    "name": "m"
+    "mode": "NULLABLE",
+    "name": "m",
+    "type": "RECORD"
   },
   {
     "mode": "NULLABLE",
-    "type": "STRING",
-    "name": "s"
+    "name": "s",
+    "type": "STRING"
   }
 ]
 END
@@ -487,8 +487,8 @@ SCHEMA
 [
   {
     "mode": "NULLABLE",
-    "name": "qi",
-    "type": "INTEGER"
+    "name": "qb",
+    "type": "BOOLEAN"
   },
   {
     "mode": "NULLABLE",
@@ -497,8 +497,8 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "qb",
-    "type": "BOOLEAN"
+    "name": "qi",
+    "type": "INTEGER"
   }
 ]
 END
@@ -511,8 +511,8 @@ SCHEMA
 [
   {
     "mode": "NULLABLE",
-    "name": "qi",
-    "type": "INTEGER"
+    "name": "qb",
+    "type": "BOOLEAN"
   },
   {
     "mode": "NULLABLE",
@@ -521,8 +521,8 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "qb",
-    "type": "BOOLEAN"
+    "name": "qi",
+    "type": "INTEGER"
   }
 ]
 END
@@ -554,7 +554,7 @@ SCHEMA
 [
   {
     "mode": "NULLABLE",
-    "name": "qi",
+    "name": "qb",
     "type": "STRING"
   },
   {
@@ -564,7 +564,7 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "qb",
+    "name": "qi",
     "type": "STRING"
   }
 ]
@@ -612,13 +612,13 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "qt",
-    "type": "TIME"
+    "name": "qdt",
+    "type": "TIMESTAMP"
   },
   {
     "mode": "NULLABLE",
-    "name": "qdt",
-    "type": "TIMESTAMP"
+    "name": "qt",
+    "type": "TIME"
   }
 ]
 END
@@ -636,12 +636,12 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "qt",
+    "name": "qdt",
     "type": "STRING"
   },
   {
     "mode": "NULLABLE",
-    "name": "qdt",
+    "name": "qt",
     "type": "STRING"
   }
 ]
@@ -718,7 +718,7 @@ SCHEMA
 [
   {
     "mode": "NULLABLE",
-    "name": "qi",
+    "name": "qb",
     "type": "STRING"
   },
   {
@@ -728,7 +728,7 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "qb",
+    "name": "qi",
     "type": "STRING"
   }
 ]
@@ -745,11 +745,6 @@ SCHEMA
 [
   {
     "mode": "NULLABLE",
-    "name": "age",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "name",
     "type": "STRING"
   },
@@ -757,6 +752,11 @@ SCHEMA
     "mode": "NULLABLE",
     "name": "surname",
     "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "age",
+    "type": "INTEGER"
   }
 ]
 END
@@ -774,11 +774,6 @@ SCHEMA
 [
   {
     "mode": "NULLABLE",
-    "name": "age",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "name",
     "type": "STRING"
   },
@@ -786,6 +781,11 @@ SCHEMA
     "mode": "NULLABLE",
     "name": "surname",
     "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "age",
+    "type": "INTEGER"
   }
 ]
 END
@@ -795,10 +795,20 @@ DATA csv
 name,surname,age,is_student,registration_date,score
 John
 Michael,Johnson,27,True,,2.0
-Maria,"","",false,2019-02-26 13:22:00 UTC,
+Maria,"",,false,2019-02-26 13:22:00 UTC,
 Joanna,Anders,21,"False",2019-02-26 13:23:00,4
 SCHEMA
 [
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "surname",
+    "type": "STRING"
+  },
   {
     "mode": "NULLABLE",
     "name": "age",
@@ -811,11 +821,6 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "name",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "registration_date",
     "type": "TIMESTAMP"
   },
@@ -823,11 +828,6 @@ SCHEMA
     "mode": "NULLABLE",
     "name": "score",
     "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "surname",
-    "type": "STRING"
   }
 ]
 END

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -1,5 +1,5 @@
 # Data with only null values should produce empty schema.
-DATA 
+DATA
 { "s": null, "a": [], "m": {} }
 SCHEMA
 []
@@ -729,6 +729,75 @@ SCHEMA
   {
     "mode": "NULLABLE",
     "name": "qb",
+    "type": "STRING"
+  }
+]
+END
+
+# Simple CSV file
+DATA csv
+name,surname,age
+John,Smith,23
+Michael,Johnson,27
+Maria,Smith,30
+Joanna,Anders,21
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "age",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "surname",
+    "type": "STRING"
+  }
+]
+END
+
+# CSV file requiring more complex type inference
+DATA csv
+name,surname,age,is_student,registration_date,score
+John,Smith,23,true,2019-02-26 13:20:00,1
+Michael,Johnson,27,True,2019-02-26T13:21:00,2.0
+Maria,Smith,30,false,2019-02-26 13:22:00 UTC,3.1
+Joanna,Anders,21,"False",2019-02-26 13:23:00,4
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "age",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_student",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "registration_date",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "score",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "surname",
     "type": "STRING"
   }
 ]


### PR DESCRIPTION
Support CSV files (inspired by #25). Adds a level of indirection using 2 adapters:
* csv.DictReader to read a CSV file with the header in the first row
* a generator to read the newline-delimited JSON file
