### PR TITLE
Infer 'REQUIRED' mode with a flag for consistently filled in values

### DIFF
--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -268,7 +268,7 @@ class SchemaGenerator:
         # might seem reasonable to allow a NULLABLE {primitive_type} to be
         # upgraded to a REPEATED {primitive_type}, but currently 'bq load' does
         # not support that so we must also follow that rule.
-        if old_mode != new_mode:
+        if old_mode != new_mode and self.infer_mode == 'false':
             raise Exception(('Mismatched mode for non-RECORD: '
                              'old=(%s,%s,%s,%s); new=(%s,%s,%s,%s)') %
                             (old_status, old_name, old_mode, old_type,

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -75,6 +75,7 @@ class SchemaGenerator:
 
     def __init__(self,
                  input_format='json',
+                 infer_mode=False,
                  keep_nulls=False,
                  quoted_values_are_strings=False,
                  debugging_interval=1000,
@@ -84,6 +85,7 @@ class SchemaGenerator:
         self.quoted_values_are_strings = quoted_values_are_strings
         self.debugging_interval = debugging_interval
         self.debugging_map = debugging_map
+        self.infer_mode = infer_mode
 
         # If CSV, force keep_nulls = True
         self.keep_nulls = True if (input_format == 'csv') else keep_nulls
@@ -198,6 +200,13 @@ class SchemaGenerator:
         old_status = old_schema_entry['status']
         new_status = new_schema_entry['status']
 
+        if old_status == 'soft' or new_status == 'soft':
+            old_schema_entry['is_likely_required'] = 'no'
+            new_schema_entry['is_likely_required'] = 'no'
+
+        if old_schema_entry['is_likely_required'] == 'undetermined' and new_status == 'hard':
+            new_schema_entry['is_likely_required'] = 'yes'
+
         # new 'soft' does not clobber old 'hard'
         if old_status == 'hard' and new_status == 'soft':
             return old_schema_entry
@@ -258,11 +267,14 @@ class SchemaGenerator:
         # might seem reasonable to allow a NULLABLE {primitive_type} to be
         # upgraded to a REPEATED {primitive_type}, but currently 'bq load' does
         # not support that so we must also follow that rule.
-        if old_mode != new_mode:
+        if old_mode != new_mode and self.infer_mode:
             raise Exception(('Mismatched mode for non-RECORD: '
                              'old=(%s,%s,%s,%s); new=(%s,%s,%s,%s)') %
                             (old_status, old_name, old_mode, old_type,
                              new_status, new_name, new_mode, new_type))
+
+        if new_schema_entry['is_likely_required'] == 'yes' and self.infer_mode == 'true':
+            new_schema_entry['info']['mode'] = 'REQUIRED'
 
         candidate_type = convert_type(old_type, new_type)
         if not candidate_type:
@@ -327,6 +339,7 @@ class SchemaGenerator:
             else:
                 status = 'hard'
             schema_entry = OrderedDict([('status', status),
+                                        ('is_likely_required', 'undetermined'),
                                         ('info', OrderedDict([
                                             ('mode', value_mode),
                                             ('name', key),
@@ -660,6 +673,7 @@ def main():
 
     generator = SchemaGenerator(
         input_format=args.input_format,
+        infer_mode=args.infer_mode,
         keep_nulls=args.keep_nulls,
         quoted_values_are_strings=args.quoted_values_are_strings,
         debugging_interval=args.debugging_interval,

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -75,11 +75,13 @@ class SchemaGenerator:
 
     def __init__(self,
                  input_format='json',
+                 infer_mode=False,
                  keep_nulls=False,
                  quoted_values_are_strings=False,
                  debugging_interval=1000,
                  debugging_map=False):
         self.input_format = input_format
+        self.infer_mode = infer_mode
         self.keep_nulls = keep_nulls
         self.quoted_values_are_strings = quoted_values_are_strings
         self.debugging_interval = debugging_interval
@@ -271,6 +273,10 @@ class SchemaGenerator:
                              'old=(%s,%s,%s,%s); new=(%s,%s,%s,%s)') %
                             (old_status, old_name, old_mode, old_type,
                              new_status, new_name, new_mode, new_type))
+
+        if new_schema_entry.get('info').get('mode') == 'NULLABLE':
+            if new_schema_entry.get('is_always_filled_in') == 'yes' and self.infer_mode == 'true':
+                    new_schema_entry.get('info').update({'mode': 'REQUIRED'})
 
         candidate_type = convert_type(old_type, new_type)
         if not candidate_type:
@@ -669,6 +675,7 @@ def main():
 
     generator = SchemaGenerator(
         input_format=args.input_format,
+        infer_mode=args.infer_mode,
         keep_nulls=args.keep_nulls,
         quoted_values_are_strings=args.quoted_values_are_strings,
         debugging_interval=args.debugging_interval,

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -268,14 +268,14 @@ class SchemaGenerator:
         # might seem reasonable to allow a NULLABLE {primitive_type} to be
         # upgraded to a REPEATED {primitive_type}, but currently 'bq load' does
         # not support that so we must also follow that rule.
-        if old_mode != new_mode and self.infer_mode == 'false':
+        if old_mode != new_mode and not self.infer_mode:
             raise Exception(('Mismatched mode for non-RECORD: '
                              'old=(%s,%s,%s,%s); new=(%s,%s,%s,%s)') %
                             (old_status, old_name, old_mode, old_type,
                              new_status, new_name, new_mode, new_type))
 
         if new_schema_entry.get('info').get('mode') == 'NULLABLE':
-            if new_schema_entry.get('is_always_filled_in') == 'yes' and self.infer_mode == 'true':
+            if new_schema_entry.get('is_always_filled_in') == 'yes' and self.infer_mode:
                     new_schema_entry.get('info').update({'mode': 'REQUIRED'})
 
         candidate_type = convert_type(old_type, new_type)
@@ -656,7 +656,7 @@ def main():
     parser.add_argument(
         '--infer_mode',
         help="If set to 'true', keys consistently having non-null values will gain 'REQUIRED' mode in the schema.",
-        default='false'
+        action='store_false'
     )
     parser.add_argument(
         '--debugging_interval',

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -75,7 +75,6 @@ class SchemaGenerator:
 
     def __init__(self,
                  input_format='json',
-                 infer_mode=False,
                  keep_nulls=False,
                  quoted_values_are_strings=False,
                  debugging_interval=1000,
@@ -85,7 +84,6 @@ class SchemaGenerator:
         self.quoted_values_are_strings = quoted_values_are_strings
         self.debugging_interval = debugging_interval
         self.debugging_map = debugging_map
-        self.infer_mode = infer_mode
 
         # If CSV, force keep_nulls = True
         self.keep_nulls = True if (input_format == 'csv') else keep_nulls
@@ -201,11 +199,12 @@ class SchemaGenerator:
         new_status = new_schema_entry['status']
 
         if old_status == 'soft' or new_status == 'soft':
-            old_schema_entry['is_likely_required'] = 'no'
-            new_schema_entry['is_likely_required'] = 'no'
+            update = {'is_always_filled_in': 'no'}
+            old_schema_entry.update(update)
+            new_schema_entry.update(update)
 
-        if old_schema_entry['is_likely_required'] == 'undetermined' and new_status == 'hard':
-            new_schema_entry['is_likely_required'] = 'yes'
+        if old_schema_entry.get('is_always_filled_in') == 'undetermined' and new_status == 'hard':
+            new_schema_entry.update({'is_always_filled_in': 'yes'})
 
         # new 'soft' does not clobber old 'hard'
         if old_status == 'hard' and new_status == 'soft':
@@ -267,14 +266,11 @@ class SchemaGenerator:
         # might seem reasonable to allow a NULLABLE {primitive_type} to be
         # upgraded to a REPEATED {primitive_type}, but currently 'bq load' does
         # not support that so we must also follow that rule.
-        if old_mode != new_mode and self.infer_mode:
+        if old_mode != new_mode:
             raise Exception(('Mismatched mode for non-RECORD: '
                              'old=(%s,%s,%s,%s); new=(%s,%s,%s,%s)') %
                             (old_status, old_name, old_mode, old_type,
                              new_status, new_name, new_mode, new_type))
-
-        if new_schema_entry['is_likely_required'] == 'yes' and self.infer_mode == 'true':
-            new_schema_entry['info']['mode'] = 'REQUIRED'
 
         candidate_type = convert_type(old_type, new_type)
         if not candidate_type:
@@ -339,7 +335,7 @@ class SchemaGenerator:
             else:
                 status = 'hard'
             schema_entry = OrderedDict([('status', status),
-                                        ('is_likely_required', 'undetermined'),
+                                        ('is_always_filled_in', 'undetermined'),
                                         ('info', OrderedDict([
                                             ('mode', value_mode),
                                             ('name', key),
@@ -673,7 +669,6 @@ def main():
 
     generator = SchemaGenerator(
         input_format=args.input_format,
-        infer_mode=args.infer_mode,
         keep_nulls=args.keep_nulls,
         quoted_values_are_strings=args.quoted_values_are_strings,
         debugging_interval=args.debugging_interval,

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -639,6 +639,11 @@ def main():
         help='Quoted values should be interpreted as strings',
         action="store_true")
     parser.add_argument(
+        '--infer_mode',
+        help="If set to 'true', keys consistently having non-null values will gain 'REQUIRED' mode in the schema.",
+        default='false'
+    )
+    parser.add_argument(
         '--debugging_interval',
         help='Number of lines between heartbeat debugging messages',
         type=int,

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -411,6 +411,7 @@ class TestFromDataFile(unittest.TestCase):
         data_flags = chunk['data_flags']
         input_format = 'csv' if ('csv' in data_flags) else 'json'
         keep_nulls = ('keep_nulls' in data_flags)
+        infer_mode = 'true' if ('infer_mode' in data_flags) else 'false'
         quoted_values_are_strings = ('quoted_values_are_strings' in data_flags)
         records = chunk['records']
         expected_errors = chunk['errors']
@@ -422,6 +423,7 @@ class TestFromDataFile(unittest.TestCase):
         # Generate schema.
         generator = SchemaGenerator(
             input_format=input_format,
+            infer_mode=infer_mode,
             keep_nulls=keep_nulls,
             quoted_values_are_strings=quoted_values_are_strings)
         schema_map, error_logs = generator.deduce_schema(records)

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -411,7 +411,7 @@ class TestFromDataFile(unittest.TestCase):
         data_flags = chunk['data_flags']
         input_format = 'csv' if ('csv' in data_flags) else 'json'
         keep_nulls = ('keep_nulls' in data_flags)
-        infer_mode = 'true' if ('infer_mode' in data_flags) else 'false'
+        infer_mode = ('infer_mode' in data_flags)
         quoted_values_are_strings = ('quoted_values_are_strings' in data_flags)
         records = chunk['records']
         expected_errors = chunk['errors']

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -831,3 +831,66 @@ SCHEMA
   }
 ]
 END
+
+# Infer 'REQUIRED' mode for a consistently filled in value - simple
+DATA csv infer_mode
+a,b,c,d,e
+,ho,hi,true
+3,hu,he,
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "a",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "b",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "c",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "d",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "e",
+    "type": "STRING"
+  }
+]
+END
+
+# Infer 'REQUIRED' mode for a consistently filled in value - complex
+DATA csv infer_mode
+name,surname,age
+John
+Michael,,
+Maria,Smith,30
+Joanna,Anders,21
+SCHEMA
+[
+  {
+    "mode": "REQUIRED",
+    "name": "name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "surname",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "age",
+    "type": "INTEGER"
+  }
+]
+END
+


### PR DESCRIPTION
Hello Brian!

Sorry for making you wait.

Here is what I wanted to have.

I've been rereading code and I've understood your confusion. 
You use `bq load` and it expects one to loose `mode` to either `NULLABLE` or `REPEATED`. The thing is that I do not use `bq load`. :) I first analyze a few given files, decide on a schema, create a table, and then start loading a lot of data continuously (I wouldn't like to discuss it too deeply). If we allow users to decide on mode only when a given flag is set, it should remain backward compatible, however please do check if I haven't broken things :) 

To me it seems like a general purpose functionality therefore I would prefer it to be open source so I really hope you won't mind having it.

If you agree to this, feel free to commit directly to my branch or branch out unless you strongly prefer to rewrite :) Also, if you just do a code review could be helpful as I am less experienced with Python.

Have a nice weekend.