### PR TITLE
0.4 - Support CSV files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 * Unreleased
+    * Support CSV input files using `--input_format` flag. Preserve
+      the ordering of fields in the schema file for CSV.
 * 0.3.2 (2019-02-24)
     * Add `--quoted_values_are_strings` flag to force quoted values (integers,
       floats, booleans) to be interpreted as a `STRING`. (Thanks de-code@,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 0.4 (2019-03-06)
     * Support CSV input files using `--input_format` flag. Preserve
       the ordering of fields in the schema file for CSV.
     * Implement `--infer_mode` flag for CSV files so that fields that are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Unreleased
     * Support CSV input files using `--input_format` flag. Preserve
       the ordering of fields in the schema file for CSV.
+    * Implement `--infer_mode` flag for CSV files so that fields that are
+      present in all input records are marked as `REQUIRED` in the schema
+      (Thanks korotkevics@, see #28).
 * 0.3.2 (2019-02-24)
     * Add `--quoted_values_are_strings` flag to force quoted values (integers,
       floats, booleans) to be interpreted as a `STRING`. (Thanks de-code@,

--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ This is required because CSV columns are defined positionally, so the schema
 file must contain all the columns specified by the CSV file, in the same
 order, even if the column contains an empty value for every record.
 
+See [Issue #26](https://github.com/bxparks/bigquery-schema-generator/issues/26)
+for implementation details.
+
 #### Keep Nulls (`--keep_nulls`)
 
 Normally when the input data file contains a field which has a null, empty
@@ -325,6 +328,9 @@ feature for JSON files, but too difficult to implement in practice because
 fields are often completely missing from a given JSON record (instead of
 explicitly being defined to be `null`).
 
+See [Issue #28](https://github.com/bxparks/bigquery-schema-generator/issues/28)
+for implementation details.
+
 #### Debugging Interval (`--debugging_interval`)
 
 By default, the `generate_schema.py` script prints a short progress message
@@ -380,6 +386,11 @@ The difference from `bq load` is that the `[time zone]` component can be only
 * `Z`
 * `UTC` (same as `Z`)
 * `(+|-)H[H][:M[M]]`
+
+Note that BigQuery supports up to 6 decimal places after the integer 'second'
+component. `generate-schema` follows the same restriction for compatibility. If
+your input file contains more than 6 decimal places, you need to write a data
+cleansing filter to fix this.
 
 The suffix `UTC` is not standard ISO 8601 nor
 [documented by Google](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#time-zones)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ the `sudo` coommand, and you can just type:
 $ pip3 install bigquery_schema_generator
 ```
 
-A successful install should print out something the following (the version
+A successful install should print out something like the following (the version
 number may be different):
 ```
 Collecting bigquery-schema-generator
@@ -88,8 +88,8 @@ command without typing in the full path.
 
 ## Usage
 
-The `generate_schema.py` script accepts a newline-delimited data file on
-the STDIN. JSON input format has been tested and supported robustly.
+The `generate_schema.py` script accepts a newline-delimited JSON or
+CSV data file on the STDIN. JSON input format has been tested extensively.
 CSV input format was added more recently (in v0.4) using the `--input_format
 csv` flag. The support is not as robust as JSON file. For example, CSV format
 supports only the comma-separator, and does not support the pipe (`|`) or tab
@@ -97,7 +97,9 @@ supports only the comma-separator, and does not support the pipe (`|`) or tab
 
 Unlike `bq load`, the `generate_schema.py` script reads every record in the
 input data file to deduce the table's schema. It prints the JSON formatted
-schema file on the STDOUT. There are at least 3 ways to run this script:
+schema file on the STDOUT.
+
+There are at least 3 ways to run this script:
 
 **1) Shell script**
 
@@ -151,7 +153,7 @@ $ bq load --source_format NEWLINE_DELIMITED_JSON \
 ```
 
 If the input file is in CSV format, the first line will be the header line which
-is needed to generate the schema. But this header line must be skipped when
+enumerates the names of the columns. But this header line must be skipped when
 importing the file into the BigQuery table. We accomplish this using
 `--skip_leading_rows` flag:
 ```
@@ -188,7 +190,7 @@ $ bq show --schema mydataset.mytable | python3 -m json.tool
 ```
 
 (The `python -m json.tool` command will pretty-print the JSON formatted schema
-file. Another alternative is the [jq command](https://stedolan.github.io/jq/).)
+file. An alternative is the [jq command](https://stedolan.github.io/jq/).)
 The resulting schema file should be identical to `file.schema.json`.
 
 ### Flag Options
@@ -491,6 +493,46 @@ $ cat file.schema.json
     "mode": "NULLABLE",
     "name": "i",
     "type": "INTEGER"
+  }
+]
+```
+
+Here is the schema generated from a CSV input file. The first line is the header
+containing the names of the columns, and the schema lists the columns in the
+same order as the header:
+```
+$ generate-schema --input_format csv
+e,b,c,d,a
+1,x,true,,2.0
+2,x,,,4
+3,,,,
+^D
+INFO:root:Processed 3 lines
+[
+  {
+    "mode": "NULLABLE",
+    "name": "e",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "b",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "c",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "d",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "a",
+    "type": "FLOAT"
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ generate-schema < file.data.json > file.schema.json
 $ generate-schema --input_format csv < file.data.csv > file.schema.json
 ```
 
-Version: 0.3.2 (2019-02-24)
+Version: 0.4 (2019-03-06)
 
 ## Background
 

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -451,7 +451,7 @@ class SchemaGenerator:
         BigQuery using the same sorting order as BigQuery.
         """
         return flatten_schema_map(schema_map, self.keep_nulls,
-            self.sorted_schema)
+                                  self.sorted_schema)
 
     def run(self):
         """Read the data records from the STDIN and print out the BigQuery
@@ -611,8 +611,8 @@ def flatten_schema_map(schema_map, keep_nulls=False, sorted_schema=True):
                     ]
                 else:
                     # Recursively flatten the sub-fields of a RECORD entry.
-                    new_value = flatten_schema_map(
-                        value, keep_nulls, sorted_schema)
+                    new_value = flatten_schema_map(value, keep_nulls,
+                                                   sorted_schema)
             elif key == 'type' and value in ['QINTEGER', 'QFLOAT', 'QBOOLEAN']:
                 new_value = value[1:]
             else:
@@ -625,7 +625,7 @@ def flatten_schema_map(schema_map, keep_nulls=False, sorted_schema=True):
 def main():
     # Configure command line flags.
     parser = argparse.ArgumentParser(
-		description='Generate BigQuery schema from JSON or CSV file.')
+        description='Generate BigQuery schema from JSON or CSV file.')
     parser.add_argument(
         '--input_format',
         help="Specify an alternative input format ('csv', 'json')",

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -595,7 +595,9 @@ def is_string_type(thetype):
     ]
 
 
-def flatten_schema_map(schema_map, keep_nulls=False, sorted_schema=True,
+def flatten_schema_map(schema_map,
+                       keep_nulls=False,
+                       sorted_schema=True,
                        infer_mode=False):
     """Converts the 'schema_map' into a more flatten version which is
     compatible with BigQuery schema.

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -203,23 +203,22 @@ class SchemaGenerator:
 
     def merge_schema_entry(self, old_schema_entry, new_schema_entry):
         """Merges the 'new_schema_entry' into the 'old_schema_entry' and return
-        a merged schema entry. Recursivesly merges in sub-fields as well.
+        a merged schema entry. Recursively merges in sub-fields as well.
 
-        Returns the merged schema_entry. This method assumes that the
-        'old_schema_entry' is no longer used by the calling code, so it often
-        modifies the old_schema_entry in-place to generate the merged
-        schema_entry.
+        Returns the merged schema_entry. This method assumes that both
+        'old_schema_entry' and 'new_schema_entry' can be modified in place and
+        returned as the new schema_entry.
         """
         if not old_schema_entry:
             return new_schema_entry
 
-        old_status = old_schema_entry['status']
-        new_status = new_schema_entry['status']
-
-        # If new or old record is 'soft', permanently set 'filled' to False
-        if new_status == 'soft' or not old_schema_entry['filled']:
+        # If a field value is missing, permanently set 'filled' to False.
+        if not new_schema_entry['filled'] or not old_schema_entry['filled']:
             old_schema_entry['filled'] = False
             new_schema_entry['filled'] = False
+
+        old_status = old_schema_entry['status']
+        new_status = new_schema_entry['status']
 
         # new 'soft' does not clobber old 'hard'
         if old_status == 'hard' and new_status == 'soft':

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -655,7 +655,7 @@ def main():
 
     generator = SchemaGenerator(
         input_format=args.input_format,
-        keep_nulls=keep_nulls,
+        keep_nulls=args.keep_nulls,
         quoted_values_are_strings=args.quoted_values_are_strings,
         debugging_interval=args.debugging_interval,
         debugging_map=args.debugging_map)

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ except:
         long_description = 'BigQuery schema generator.'
 
 setup(name='bigquery-schema-generator',
-      version='0.3.2',
-      description='BigQuery schema generator',
+      version='0.4',
+      description='BigQuery schema generator from JSON or CSV data',
       long_description=long_description,
       url='https://github.com/bxparks/bigquery-schema-generator',
       author='Brian T. Park',

--- a/tests/data_reader.py
+++ b/tests/data_reader.py
@@ -142,15 +142,16 @@ class DataReader:
             return (None, None)
         (tag, data_flags) = self.parse_tag_line(tag_line)
         if tag != 'DATA':
-            raise Exception("Unrecoginized tag line '%s', should be DATA" %
-                            tag_line)
+            raise Exception(
+                "Unrecoginized tag line '%s', should be DATA" % tag_line)
 
         # Read the DATA records until the next TAG_TOKEN.
         records = []
         while True:
             line = self.read_line()
             if line is None:
-                raise Exception("Unexpected EOF, should be ERRORS or SCHEMA tag")
+                raise Exception(
+                    "Unexpected EOF, should be ERRORS or SCHEMA tag")
             (tag, _) = self.parse_tag_line(line)
             if tag in self.TAG_TOKENS:
                 if tag == 'DATA':
@@ -204,8 +205,8 @@ class DataReader:
             raise Exception("Unexpected EOF, should be SCHEMA tag")
         (tag, _) = self.parse_tag_line(tag_line)
         if tag != 'SCHEMA':
-            raise Exception("Unrecoginized tag line '%s', should be SCHEMA" %
-                            tag_line)
+            raise Exception(
+                "Unrecoginized tag line '%s', should be SCHEMA" % tag_line)
 
         # Read the SCHEMA records until the next TAG_TOKEN
         schema_lines = []
@@ -230,8 +231,8 @@ class DataReader:
             raise Exception("Unexpected EOF, should be END tag")
         (tag, _) = self.parse_tag_line(tag_line)
         if tag != 'END':
-            raise Exception("Unrecoginized tag line '%s', should be END" %
-                            tag_line)
+            raise Exception(
+                "Unrecoginized tag line '%s', should be END" % tag_line)
 
     def parse_tag_line(self, line):
         """Parses a potential tag line of the form 'TAG [flags...]' where

--- a/tests/data_reader.py
+++ b/tests/data_reader.py
@@ -163,8 +163,8 @@ class DataReader:
         return (data_flags, records)
 
     def read_errors_section(self):
-        """Return a dictionary of errors which are expected from the parsing of the
-        DATA section. The dict has the form:
+        """Return a dictionary of errors which are expected from the parsing of
+        the DATA section. The dict has the form:
             {
                 'line': line,
                 'msg': [ messages ...]

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -411,6 +411,7 @@ class TestFromDataFile(unittest.TestCase):
         data_flags = chunk['data_flags']
         input_format = 'csv' if ('csv' in data_flags) else 'json'
         keep_nulls = ('keep_nulls' in data_flags)
+        infer_mode = ('infer_mode' in data_flags)
         quoted_values_are_strings = ('quoted_values_are_strings' in data_flags)
         records = chunk['records']
         expected_errors = chunk['errors']
@@ -422,6 +423,7 @@ class TestFromDataFile(unittest.TestCase):
         # Generate schema.
         generator = SchemaGenerator(
             input_format=input_format,
+            infer_mode=infer_mode,
             keep_nulls=keep_nulls,
             quoted_values_are_strings=quoted_values_are_strings)
         schema_map, error_logs = generator.deduce_schema(records)

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -831,3 +831,66 @@ SCHEMA
   }
 ]
 END
+
+# Infer 'REQUIRED' mode for a consistently filled in value - simple
+DATA csv infer_mode
+a,b,c,d,e
+,ho,hi,true
+3,hu,he,
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "a",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "b",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "c",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "d",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "e",
+    "type": "STRING"
+  }
+]
+END
+
+# Infer 'REQUIRED' mode for a consistently filled in value - complex
+DATA csv infer_mode
+name,surname,age
+John
+Michael,,
+Maria,Smith,30
+Joanna,Anders,21
+SCHEMA
+[
+  {
+    "mode": "REQUIRED",
+    "name": "name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "surname",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "age",
+    "type": "INTEGER"
+  }
+]
+END
+

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -1,5 +1,5 @@
 # Data with only null values should produce empty schema.
-DATA 
+DATA
 { "s": null, "a": [], "m": {} }
 SCHEMA
 []
@@ -13,25 +13,25 @@ SCHEMA
 [
   {
     "mode": "REPEATED",
-    "type": "STRING",
-    "name": "a"
+    "name": "a",
+    "type": "STRING"
   },
   {
-    "mode": "NULLABLE",
     "fields": [
       {
         "mode": "NULLABLE",
-        "type": "STRING",
-        "name": "__unknown__"
+        "name": "__unknown__",
+        "type": "STRING"
       }
     ],
-    "type": "RECORD",
-    "name": "m"
+    "mode": "NULLABLE",
+    "name": "m",
+    "type": "RECORD"
   },
   {
     "mode": "NULLABLE",
-    "type": "STRING",
-    "name": "s"
+    "name": "s",
+    "type": "STRING"
   }
 ]
 END
@@ -487,8 +487,8 @@ SCHEMA
 [
   {
     "mode": "NULLABLE",
-    "name": "qi",
-    "type": "INTEGER"
+    "name": "qb",
+    "type": "BOOLEAN"
   },
   {
     "mode": "NULLABLE",
@@ -497,8 +497,8 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "qb",
-    "type": "BOOLEAN"
+    "name": "qi",
+    "type": "INTEGER"
   }
 ]
 END
@@ -511,8 +511,8 @@ SCHEMA
 [
   {
     "mode": "NULLABLE",
-    "name": "qi",
-    "type": "INTEGER"
+    "name": "qb",
+    "type": "BOOLEAN"
   },
   {
     "mode": "NULLABLE",
@@ -521,8 +521,8 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "qb",
-    "type": "BOOLEAN"
+    "name": "qi",
+    "type": "INTEGER"
   }
 ]
 END
@@ -554,7 +554,7 @@ SCHEMA
 [
   {
     "mode": "NULLABLE",
-    "name": "qi",
+    "name": "qb",
     "type": "STRING"
   },
   {
@@ -564,7 +564,7 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "qb",
+    "name": "qi",
     "type": "STRING"
   }
 ]
@@ -612,13 +612,13 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "qt",
-    "type": "TIME"
+    "name": "qdt",
+    "type": "TIMESTAMP"
   },
   {
     "mode": "NULLABLE",
-    "name": "qdt",
-    "type": "TIMESTAMP"
+    "name": "qt",
+    "type": "TIME"
   }
 ]
 END
@@ -636,12 +636,12 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "qt",
+    "name": "qdt",
     "type": "STRING"
   },
   {
     "mode": "NULLABLE",
-    "name": "qdt",
+    "name": "qt",
     "type": "STRING"
   }
 ]
@@ -718,7 +718,7 @@ SCHEMA
 [
   {
     "mode": "NULLABLE",
-    "name": "qi",
+    "name": "qb",
     "type": "STRING"
   },
   {
@@ -728,8 +728,106 @@ SCHEMA
   },
   {
     "mode": "NULLABLE",
-    "name": "qb",
+    "name": "qi",
     "type": "STRING"
+  }
+]
+END
+
+# Simple CSV file
+DATA csv
+name,surname,age
+John,Smith,23
+Michael,Johnson,27
+Maria,Smith,30
+Joanna,Anders,21
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "surname",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "age",
+    "type": "INTEGER"
+  }
+]
+END
+
+# A missing field (no comma-separator) is read as a 'null'. An empty field is
+# read as an empty string ("") but should be interpreted to be a 'null' to
+# allow subsequent non-null fields to determine the type.
+DATA csv
+name,surname,age
+John
+Michael,,
+Maria,Smith,30
+Joanna,Anders,21
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "surname",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "age",
+    "type": "INTEGER"
+  }
+]
+END
+
+# CSV file requiring more complex type inference
+DATA csv
+name,surname,age,is_student,registration_date,score
+John
+Michael,Johnson,27,True,,2.0
+Maria,"",,false,2019-02-26 13:22:00 UTC,
+Joanna,Anders,21,"False",2019-02-26 13:23:00,4
+SCHEMA
+[
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "surname",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "age",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_student",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "registration_date",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "score",
+    "type": "FLOAT"
   }
 ]
 END

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -893,4 +893,3 @@ SCHEMA
   }
 ]
 END
-


### PR DESCRIPTION
* 0.4 (2019-03-06)
    * Support CSV input files using `--input_format` flag. Preserve
      the ordering of fields in the schema file for CSV.
    * Implement `--infer_mode` flag for CSV files so that fields that are
      present in all input records are marked as `REQUIRED` in the schema
      (Thanks korotkevics@, see #28).