### PR TITLE
0.5 - remove fields with unsolvable errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-* Unreleased
+* 0.5 (2019-06-06)
     * Add input and output parameters to run() to allow the client code using
       `SchemaGenerator` to redirect the input and output files. (See #30).
+    * Remove fields with incompatible types (or other errors) from the generated
+      schema, instead of picking the type of the first encounter. (See #31).
+    * Improve internal data validation handling, reserving exceptions for
+      programming errors only.
 * 0.4 (2019-03-06)
     * Support CSV input files using `--input_format` flag. Preserve
       the ordering of fields in the schema file for CSV.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 * Unreleased
+    * Add input and output parameters to run() to allow the client code using
+      `SchemaGenerator` to redirect the input and output files. (See #30).
 * 0.4 (2019-03-06)
     * Support CSV input files using `--input_format` flag. Preserve
       the ordering of fields in the schema file for CSV.

--- a/README.md
+++ b/README.md
@@ -595,8 +595,8 @@ Generating the schema using
 $ bigquery_schema_generator/generate_schema.py < anon1.data.json \
     > anon1.schema.json
 ```
-took 77s on a Dell Precision M4700 laptop with an Intel Core i7-3840QM CPU @
-2.80GHz, 32GB of RAM, Ubuntu Linux 17.10, Python 3.6.3.
+took 67s on a Dell Precision M4700 laptop with an Intel Core i7-3840QM CPU @
+2.80GHz, 32GB of RAM, Ubuntu Linux 18.04, Python 3.6.7.
 
 ## System Requirements
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ generate-schema < file.data.json > file.schema.json
 $ generate-schema --input_format csv < file.data.csv > file.schema.json
 ```
 
-Version: 0.4 (2019-03-06)
+Version: 0.5 (2019-06-06)
 
 ## Background
 
@@ -579,6 +579,41 @@ INFO:root:Processed 4 lines
 ]
 ```
 
+## Using As a Library
+
+The `bigquery_schema_generator` module can be used as a library by an external
+Python client code by creating an instance of `SchemaGenerator` and calling the
+`run(input, output)` method:
+
+```python
+from bigquery_schema_generator.generate_schema import SchemaGenerator
+
+generator = SchemaGenerator(
+    input_format=input_format,
+    infer_mode=infer_mode,
+    keep_nulls=keep_nulls,
+    quoted_values_are_strings=quoted_values_are_strings,
+    debugging_interval=debugging_interval,
+    debugging_map=debugging_map)
+generator.run(input_file, output_file)
+```
+
+If you need to process the generated schema programmatically, use the
+`deduce_schema()` method and process the resulting `schema_map` and `error_log`
+data structures like this:
+
+```python
+from bigquery_schema_generator.generate_schema import SchemaGenerator
+...
+schema_map, error_logs = generator.deduce_schema(input_file)
+
+for error in error_logs:
+    logging.info("Problem on line %s: %s", error['line'], error['msg'])
+
+schema = generator.flatten_schema(schema_map)
+json.dump(schema, output_file, indent=2)
+```
+
 ## Benchmarks
 
 I wrote the `bigquery_schema_generator/anonymize.py` script to create an
@@ -622,6 +657,9 @@ See [CHANGELOG.md](CHANGELOG.md).
   (de-code@).
 * Support for CSV files and detection of `REQUIRED` fields by Sandor Korotkevics
   (korotkevics@).
+* Better support for using `bigquery_schema_generator` as a library from an
+  external Python code by StefanoG_ITA (@StefanoGITA).
+
 
 ## License
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except:
         long_description = 'BigQuery schema generator.'
 
 setup(name='bigquery-schema-generator',
-      version='0.4',
+      version='0.5',
       description='BigQuery schema generator from JSON or CSV data',
       long_description=long_description,
       url='https://github.com/bxparks/bigquery-schema-generator',

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -17,6 +17,7 @@
 import unittest
 import os
 import json
+from io import StringIO
 from collections import OrderedDict
 from bigquery_schema_generator.generate_schema import SchemaGenerator
 from bigquery_schema_generator.generate_schema import is_string_type
@@ -380,6 +381,22 @@ class TestSchemaGenerator(unittest.TestCase):
         self.assertTrue(is_string_type('TIMESTAMP'))
         self.assertTrue(is_string_type('DATE'))
         self.assertTrue(is_string_type('TIME'))
+
+    def test_run_with_input_and_output(self):
+        generator = SchemaGenerator()
+        input = StringIO('{ "name": "1" }')
+        output = StringIO()
+        generator.run(input, output)
+        expected = """\
+[
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "INTEGER"
+  }
+]
+"""
+        self.assertEqual(expected, output.getvalue())
 
 
 class TestFromDataFile(unittest.TestCase):

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -230,16 +230,14 @@ class TestSchemaGenerator(unittest.TestCase):
                          generator.infer_bigquery_type([{}]))
 
         # Cannot have arrays of nulls (REPEATED __null__)
-        with self.assertRaises(Exception):
-            generator.infer_bigquery_type([None])
+        self.assertEqual((None, None), generator.infer_bigquery_type([None]))
 
         # Cannot have arrays of empty arrays: (REPEATED __empty_array__)
-        with self.assertRaises(Exception):
-            generator.infer_bigquery_type([[], []])
+        self.assertEqual((None, None), generator.infer_bigquery_type([[], []]))
 
         # Cannot have arrays of arrays: (REPEATED __array__)
-        with self.assertRaises(Exception):
-            generator.infer_bigquery_type([[1, 2], [2]])
+        self.assertEqual((None, None),
+            generator.infer_bigquery_type([[1, 2], [2]]))
 
     def test_infer_array_type(self):
         generator = SchemaGenerator()

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -275,6 +275,15 @@ SCHEMA
 ]
 END
 
+# Arrays of Arrays not allowed.
+DATA
+{ "a": [[]] }
+ERRORS
+1: Unsupported array element type: __empty_array__
+SCHEMA
+[]
+END
+
 # All elements of an array must be of the same type. Also check that an error
 # in one element ("a") continues the processing the remaining elements. (The
 # bug was caused by a missing try/except block while looping over each
@@ -282,7 +291,7 @@ END
 DATA
 { "s": "string", "x": 3.2, "i": 3, "b": true, "a": [ "a", 1] }
 ERRORS
-1: Not all array elements are equal type: ['a', 1]
+1: All array elements must be the same compatible type: ['a', 1]
 SCHEMA
 [
   {

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -112,15 +112,9 @@ DATA
 { "ts": "2017-05-22T17:10:00-07:00" }
 { "ts": 1.0 }
 ERRORS
-2: Mismatched type: old=(hard,d,NULLABLE,DATE); new=(hard,d,NULLABLE,FLOAT)
+2: Ignoring field with mismatched type: old=(hard,ts,NULLABLE,TIMESTAMP); new=(hard,ts,NULLABLE,FLOAT)
 SCHEMA
-[
-  {
-    "mode": "NULLABLE",
-    "name": "ts",
-    "type": "TIMESTAMP"
-  }
-]
+[]
 END
 
 # DATE cannot change into a non-String type.
@@ -128,15 +122,9 @@ DATA
 { "d": "2017-01-01" }
 { "d": 1.0 }
 ERRORS
-2: Mismatched type: old=(hard,d,NULLABLE,DATE); new=(hard,d,NULLABLE,FLOAT)
+2: Ignoring field with mismatched type: old=(hard,d,NULLABLE,DATE); new=(hard,d,NULLABLE,FLOAT)
 SCHEMA
-[
-  {
-    "mode": "NULLABLE",
-    "name": "d",
-    "type": "DATE"
-  }
-]
+[]
 END
 
 # TIME cannot change into a non-String type.
@@ -144,15 +132,9 @@ DATA
 { "t": "17:10:01" }
 { "t": 1.0 }
 ERRORS
-2: Mismatched type: old=(hard,d,NULLABLE,DATE); new=(hard,d,NULLABLE,FLOAT)
+2: Ignoring field with mismatched type: old=(hard,t,NULLABLE,TIME); new=(hard,t,NULLABLE,FLOAT)
 SCHEMA
-[
-  {
-    "mode": "NULLABLE",
-    "name": "t",
-    "type": "TIME"
-  }
-]
+[]
 END
 
 # Conflicting TIME or DATE field reduces to STRING.
@@ -405,15 +387,9 @@ DATA
 { "i": 3 }
 { "i": [1, 2] }
 ERRORS
-2: Mismatched mode for non-RECORD: old=(hard,i,NULLABLE,INTEGER); new=(hard,i,REPEATED,INTEGER)
+2: Ignoring non-RECORD field with mismatched mode: old=(hard,i,NULLABLE,INTEGER); new=(hard,i,REPEATED,INTEGER)
 SCHEMA
-[
-  {
-    "mode": "NULLABLE",
-    "name": "i",
-    "type": "INTEGER"
-  }
-]
+[]
 END
 
 # No downgrade of REPEATED to NULLABLE.
@@ -421,15 +397,9 @@ DATA
 { "i": [1, 2] }
 { "i": 3 }
 ERRORS
-2: Mismatched mode for non-RECORD: old=(hard,i,REPEATED,INTEGER); new=(hard,i,NULLABLE,INTEGER)
+2: Ignoring non-RECORD field with mismatched mode: old=(hard,i,REPEATED,INTEGER); new=(hard,i,NULLABLE,INTEGER)
 SCHEMA
-[
-  {
-    "mode": "REPEATED",
-    "name": "i",
-    "type": "INTEGER"
-  }
-]
+[]
 END
 
 # NULLABLE RECORD can be upgraded to a REPEATED RECORD.


### PR DESCRIPTION
* 0.5 (2019-06-06)
    * Add input and output parameters to run() to allow the client code using
      `SchemaGenerator` to redirect the input and output files. (See #30).
    * Remove fields with incompatible types (or other errors) from the generated
      schema, instead of picking the type of the first encounter. (See #31).
    * Improve internal data validation handling, reserving exceptions for
      programming errors only.