### PR TITLE
0.5.1 - add '--sanitize_names' flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 0.5.1 (2019-06-17)
     * Add `--sanitize_names` to convert invalid characters in column names and
       to shorten them if too long. (See #33; thanks @jonwarghed).
 * 0.5 (2019-06-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* Unreleased
+    * Add `--sanitize_names` to convert invalid characters in column names and
+      to shorten them if too long. (See #33; thanks @jonwarghed).
 * 0.5 (2019-06-06)
     * Add input and output parameters to run() to allow the client code using
       `SchemaGenerator` to redirect the input and output files. (See #30).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ generate-schema < file.data.json > file.schema.json
 $ generate-schema --input_format csv < file.data.csv > file.schema.json
 ```
 
-Version: 0.5 (2019-06-06)
+Version: 0.5.1 (2019-06-19)
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -204,10 +204,10 @@ Print the built-in help strings:
 
 ```
 $ generate-schema --help
-usage: generate-schema [-h] [--input_format INPUT_FORMAT] [--keep_nulls]
-                       [--quoted_values_are_strings] [--infer_mode]
-                       [--debugging_interval DEBUGGING_INTERVAL]
-                       [--debugging_map]
+usage: generate_schema.py [-h] [--input_format INPUT_FORMAT] [--keep_nulls]
+                          [--quoted_values_are_strings] [--infer_mode]
+                          [--debugging_interval DEBUGGING_INTERVAL]
+                          [--debugging_map] [--sanitize_names]
 
 Generate BigQuery schema from JSON or CSV file.
 
@@ -223,7 +223,8 @@ optional arguments:
   --debugging_interval DEBUGGING_INTERVAL
                         Number of lines between heartbeat debugging messages
   --debugging_map       Print the metadata schema_map instead of the schema
-                        for debugging
+  --sanitize_names      Forces schema name to comply with BigQuery naming
+                        standard
 ```
 
 #### Input Format (`--input_format`)
@@ -351,6 +352,14 @@ flag is intended to be used for debugging.
 ```
 $ generate-schema --debugging_map < file.data.json > file.schema.json
 ```
+
+#### Sanitize Names (`--sanitize_names`)
+
+BigQuery column names are restricted to certain characters and length. With this
+flag, column names are sanitizes so that any character outside of ASCII letters,
+numbers and underscore (`[a-zA-Z0-9_]`) are converted to an underscore. (For
+example "go&2#there!" is converted to "go_2_there_".) Names longer than 128
+characters are truncated to 128.
 
 ## Schema Types
 
@@ -658,7 +667,9 @@ See [CHANGELOG.md](CHANGELOG.md).
 * Support for CSV files and detection of `REQUIRED` fields by Sandor Korotkevics
   (korotkevics@).
 * Better support for using `bigquery_schema_generator` as a library from an
-  external Python code by StefanoG_ITA (@StefanoGITA).
+  external Python code by StefanoG_ITA (StefanoGITA@).
+* Sanitizing of column names to valid BigQuery characters and length by Jon
+  Warghed (jonwarghed@).
 
 
 ## License

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -115,7 +115,7 @@ class SchemaGenerator:
         # This option generally wants to be turned on as any inferred schema
         # will not be accepted by `bq load` when it contains illegal characters.
         # Characters such as #, / or -. Neither will it be accepted if the column name
-        # in the schema is larger than 128 characters. 
+        # in the schema is larger than 128 characters.
         self.sanitize_names = sanitize_names
 
     def log_error(self, msg):
@@ -206,8 +206,8 @@ class SchemaGenerator:
         for key, value in json_object.items():
             schema_entry = schema_map.get(key)
             new_schema_entry = self.get_schema_entry(key, value)
-            schema_map[key] = self.merge_schema_entry(
-                schema_entry, new_schema_entry)
+            schema_map[key] = self.merge_schema_entry(schema_entry,
+                                                      new_schema_entry)
 
     def merge_schema_entry(self, old_schema_entry, new_schema_entry):
         """Merges the 'new_schema_entry' into the 'old_schema_entry' and return
@@ -471,8 +471,8 @@ class SchemaGenerator:
             else:
                 return '__empty_array__'
         else:
-            raise Exception('Unsupported node type: %s (should not happen)'
-                % type(value))
+            raise Exception(
+                'Unsupported node type: %s (should not happen)' % type(value))
 
     def infer_array_type(self, elements):
         """Return the type of all the array elements, accounting for the same
@@ -678,8 +678,8 @@ def flatten_schema_map(schema_map,
                     ]
                 else:
                     # Recursively flatten the sub-fields of a RECORD entry.
-                    new_value = flatten_schema_map(value, keep_nulls,
-                                                   sorted_schema, sanitize_names)
+                    new_value = flatten_schema_map(
+                        value, keep_nulls, sorted_schema, sanitize_names)
             elif key == 'type' and value in ['QINTEGER', 'QFLOAT', 'QBOOLEAN']:
                 new_value = value[1:]
             elif key == 'mode':

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except:
         long_description = 'BigQuery schema generator.'
 
 setup(name='bigquery-schema-generator',
-      version='0.5',
+      version='0.5.1',
       description='BigQuery schema generator from JSON or CSV data',
       long_description=long_description,
       url='https://github.com/bxparks/bigquery-schema-generator',

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -237,7 +237,7 @@ class TestSchemaGenerator(unittest.TestCase):
 
         # Cannot have arrays of arrays: (REPEATED __array__)
         self.assertEqual((None, None),
-            generator.infer_bigquery_type([[1, 2], [2]]))
+                         generator.infer_bigquery_type([[1, 2], [2]]))
 
     def test_infer_array_type(self):
         generator = SchemaGenerator()

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -904,4 +904,3 @@ SCHEMA
   }
 ]
 END
-


### PR DESCRIPTION
* 0.5.1 (2019-06-17)
    * Add `--sanitize_names` to convert invalid characters in column names and
      to shorten them if too long. (See #33; thanks @jonwarghed).
