### PR TITLE
Add support for starting from exising BQ schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.tox/

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -272,9 +272,13 @@ class SchemaGenerator:
 
         # Defensive check, names should always be the same.
         if old_name != new_name:
-            raise Exception(
-                'old_name (%s) != new_name(%s), should never happen' %
-                (old_name, new_name))
+            if old_name.lower() != new_name.lower():
+                raise Exception(
+                    'old_name (%s) != new_name(%s), should never happen' %
+                    (old_name, new_name))
+            else:
+                # preserve old name if case is different
+                new_info['name'] = old_info['name']
 
         # Recursively merge in the subfields of a RECORD, allowing
         # NULLABLE to become REPEATED (because 'bq load' allows it).

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -80,13 +80,15 @@ class SchemaGenerator:
                  quoted_values_are_strings=False,
                  debugging_interval=1000,
                  debugging_map=False,
-                 sanitize_names=False):
+                 sanitize_names=False,
+                 type_mismatch_callback=None):
         self.input_format = input_format
         self.infer_mode = infer_mode
         self.keep_nulls = keep_nulls
         self.quoted_values_are_strings = quoted_values_are_strings
         self.debugging_interval = debugging_interval
         self.debugging_map = debugging_map
+        self.type_mismatch_callback = type_mismatch_callback
 
         # 'infer_mode' is supported for only input_format = 'csv' because
         # the header line gives us the complete list of fields to be expected in
@@ -325,6 +327,9 @@ class SchemaGenerator:
 
         # Check that the converted types are compatible.
         candidate_type = convert_type(old_type, new_type)
+        if not candidate_type and self.type_mismatch_callback:
+            # inconvertible -> check if the caller has additional insight
+            candidate_type = self.type_mismatch_callback(old_type, new_type)
         if not candidate_type:
             self.log_error(
                 f'Ignoring field with mismatched type: '

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -206,11 +206,11 @@ class SchemaGenerator:
         then they must be compatible.
         """
         for key, value in json_object.items():
-            key = self.sanitize_name(key)
-            schema_entry = schema_map.get(key)
+            sanitized_key = self.sanitize_name(key)
+            schema_entry = schema_map.get(sanitized_key)
             new_schema_entry = self.get_schema_entry(key, value)
-            schema_map[key] = self.merge_schema_entry(schema_entry,
-                                                      new_schema_entry)
+            schema_map[sanitized_key] = self.merge_schema_entry(schema_entry,
+                                                                new_schema_entry)
 
     def sanitize_name(self, value):
         if self.sanitize_names:
@@ -751,13 +751,13 @@ def bq_schema_field_to_entry(field):
         info = OrderedDict([
             ('fields', bq_schema_to_map(field['fields'])),
             ('mode', field['mode']),
-            ('name', field['name'].lower()),
+            ('name', field['name']),
             ('type', type),
         ])
     else:
         info = OrderedDict([
             ('mode', field['mode']),
-            ('name', field['name'].lower()),
+            ('name', field['name']),
             ('type', type),
         ])
     return OrderedDict([

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -217,7 +217,7 @@ class SchemaGenerator:
             new_value = re.sub('[^a-zA-Z0-9_]', '_', value[:127])
         else:
             new_value = value
-        return new_value
+        return new_value.lower()
 
 
     def merge_schema_entry(self, old_schema_entry, new_schema_entry):

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -712,7 +712,7 @@ def bq_schema_to_map(schema):
     """ convert BQ JSON table schema representation to SchemaGenerator schema_map representaton """
     if isinstance(schema, dict):
         schema = schema['fields']
-    return OrderedDict((f['name'], bq_schema_field_to_entry(f))
+    return OrderedDict((f['name'].lower(), bq_schema_field_to_entry(f))
                        for f in schema)
 
 
@@ -751,13 +751,13 @@ def bq_schema_field_to_entry(field):
         info = OrderedDict([
             ('fields', bq_schema_to_map(field['fields'])),
             ('mode', field['mode']),
-            ('name', field['name']),
+            ('name', field['name'].lower()),
             ('type', type),
         ])
     else:
         info = OrderedDict([
             ('mode', field['mode']),
-            ('name', field['name']),
+            ('name', field['name'].lower()),
             ('type', type),
         ])
     return OrderedDict([

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+# These are the assumed default build requirements from pip:
+# https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,10 @@ setup(name='bigquery-schema-generator',
           'console_scripts': [
             'generate-schema = bigquery_schema_generator.generate_schema:main'
         ]
-      }
+      },
+      extras_require={
+          'dev': [
+              'pytest',
+          ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,14 @@ setup(name='bigquery-schema-generator',
       },
       extras_require={
           'dev': [
+              'flake8',
               'pytest',
+              'tox',
+              'wheel',
+              'setuptools',
           ],
+        'test': [
+            'coverage',
+        ],
     },
 )

--- a/tests/data_reader.py
+++ b/tests/data_reader.py
@@ -216,8 +216,8 @@ class DataReader:
                 break
             (tag, _) = self.parse_tag_line(line)
             if tag in self.TAG_TOKENS:
-                if tag == 'SCHEMA':
-                    raise Exception("Unexpected SCHEMA tag")
+                if tag in ('DATA', 'ERROR', 'SCHEMA'):
+                    raise Exception("Unexpected {} tag".format(tag))
                 self.push_back(line)
                 break
             schema_lines.append(line)

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -248,6 +248,8 @@ DATA
 { "a": [1, 3], "r": [{ "r0": "r0", "r1": "r1" }] }
 ERRORS
 2: Converting schema for "r" from NULLABLE RECORD into REPEATED RECORD
+ERRORS INFORMED
+# none
 SCHEMA
 [
   {
@@ -407,6 +409,8 @@ DATA
 { "i": 3 }
 ERRORS
 2: Ignoring non-RECORD field with mismatched mode: old=(hard,i,REPEATED,INTEGER); new=(hard,i,NULLABLE,INTEGER)
+ERRORS INFORMED
+2: Converting schema for "r" from NULLABLE RECORD into REPEATED RECORD
 SCHEMA
 []
 END
@@ -417,6 +421,8 @@ DATA
 { "r" : [{ "i": 4 }] }
 ERRORS
 2: Converting schema for "r" from NULLABLE RECORD into REPEATED RECORD
+ERRORS INFORMED
+1: Leaving schema for "r" as REPEATED RECORD
 SCHEMA
 [
   {
@@ -811,7 +817,7 @@ SCHEMA
 ]
 END
 
-# Infer 'REQUIRED' mode for a consistently filled in value - simple
+# Infer 'REQUIR ED' mode for a consistently filled in value - simple
 DATA csv infer_mode
 a,b,c,d,e
 ,ho,hi,true

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,27 @@
+[tox]
+envlist = py{35,36,37}
+skip_missing_interpreters = True
+
+# Define the minimal tox version required to run;
+# if the host tox is less than this the tool with create an environment and
+# provision it with a tox that satisfies it under provision_tox_env.
+# At least this version is needed for PEP 517/518 support.
+minversion = 3.3.0
+
+# Activate isolated build environment. tox will use a virtual environment
+# to build a source distribution from the source tree. For build tools and
+# arguments use the pyproject.toml file as specified in PEP-517 and PEP-518.
+isolated_build = true
+
+[testenv]
+deps =
+    flake8
+    pytest
+commands =
+    python setup.py check -m -s
+    # flake8 .
+    py.test tests {posargs}
+
+[flake8]
+exclude = .tox,*.egg,build,data
+select = E,W,F


### PR DESCRIPTION
We're loading a kafka topic to BQ. It seems prudent to inform SchemaGenerator of existing BQ table schema before processing new records as this reduces the chances for misdetection.