### PR TITLE
fix recursive sanitization of field names in records of type RECORD

### DIFF
--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -679,7 +679,7 @@ def flatten_schema_map(schema_map,
                 else:
                     # Recursively flatten the sub-fields of a RECORD entry.
                     new_value = flatten_schema_map(
-                        value, keep_nulls, sorted_schema, sanitize_names)
+                        value, keep_nulls, sorted_schema, infer_mode, sanitize_names)
             elif key == 'type' and value in ['QINTEGER', 'QFLOAT', 'QBOOLEAN']:
                 new_value = value[1:]
             elif key == 'mode':

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -873,6 +873,26 @@ SCHEMA
 ]
 END
 
+# Sanitize the names to comply with BigQuery recursively.
+DATA sanitize_names
+{ "r" : { "a-name": [1, 2] } }
+SCHEMA
+[
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "a_name",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "r",
+    "type": "RECORD"
+  }
+]
+END
+
 # Sanitize the names to comply with BigQuery.
 DATA csv infer_mode sanitize_names
 name,surname,age_in_#years,eighteencharacterseighteencharacterseighteencharacterseighteencharacterseighteencharacterseighteencharacterseighteencharacterseighteencharacters


### PR DESCRIPTION
See issue #43. There seem to be a parameter missing in the recursive call to `flatten_schema_map`.