### PR TITLE
[WIP] Empty nested records with keep_nulls=False produce a record with no fields

### DIFF
--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -791,8 +791,8 @@ def flatten_schema_map(
             else:
                 new_value = value
             new_info[key] = new_value
-        # This check will remove record fields where all nested record values are null.
-        # For additional context see:
+        # This check will remove record fields where all nested record values
+        # are null. For additional context see:
         # https://github.com/bxparks/bigquery-schema-generator/issues/55
         if keep_nulls or record_filled or fields_key_missing:
             schema.append(new_info)

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -29,7 +29,6 @@ Usage:
 * file.schema.json is the schema definition of the table.
 """
 
-from IPython import embed
 from collections import OrderedDict
 import argparse
 import json

--- a/tests/testdata.txt
+++ b/tests/testdata.txt
@@ -733,8 +733,8 @@ SCHEMA
 END
 
 # Incompatible types error printing full path
-# given
-DATA
+# given. Keeping nulls
+DATA keep_nulls
 {"source_machine":{"port":80},"dest_machine":{"port":80}}
 {"source_machine":{"port":80},"dest_machine":{"port":"http-port"}}
 ERRORS
@@ -758,6 +758,75 @@ SCHEMA
     "mode": "NULLABLE",
     "name": "source_machine",
     "type": "RECORD"
+  }
+]
+END
+
+# Removing null inner nested_fields from schema
+DATA
+{"test": "thing", "empty_record": {}, "outer_nested_record": {"inner_empty_record": {}}, "filled_record": {"full_of_stuff": "totally"}}
+SCHEMA
+[
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "full_of_stuff",
+        "type": "STRING"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "filled_record",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "test",
+    "type": "STRING"
+  }
+]
+END
+
+# Removing null inner nested_fields from schema keeping when 1 line has data
+DATA
+{"test": "thing", "empty_record": {}, "outer_nested_record": {"inner_empty_record": {}}, "filled_record": {"full_of_stuff": "totally"}}
+{"test": "thing", "empty_record": {}, "outer_nested_record": {"inner_empty_record": {"something": "exists"}}, "filled_record": {"full_of_stuff": "totally"}}
+SCHEMA
+[
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "full_of_stuff",
+        "type": "STRING"
+      }                                                                                                        ],
+    "mode": "NULLABLE",
+    "name": "filled_record",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "something",
+            "type": "STRING"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "inner_empty_record",
+        "type": "RECORD"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "outer_nested_record",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "test",
+    "type": "STRING"
   }
 ]
 END


### PR DESCRIPTION
Context exists in issue #55, empty nested records not removed. Copying and pasting context below:

# Summary
When we remove nulls we are only removing inner nulls and not the case where a record has all fields removed during this process. This produces the following error when attempting to load into BigQuery with the generated schema:
`Field outer_nested_record is type RECORD but has no schema.`

# Example input
test_data.json
```json
{"test": "thing", "empty_record": {}, "outer_nested_record": {"inner_empty_record": {}}}
```

# Command Ran
```bash
generate-schema --input_format json --quoted_values_are_strings < test_file.json
```
# Current Output
```json
[
  {
    "fields": [],
    "mode": "NULLABLE",
    "name": "outer_nested_record",
    "type": "RECORD"
  },
  {
    "mode": "NULLABLE",
    "name": "test",
    "type": "STRING"
  }
]
```

# Expected Output
```json
[
  {
    "mode": "NULLABLE",
    "name": "test",
    "type": "STRING"
  }
]
```



