### PR TITLE
Schema augmentation function

### DIFF
--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -62,7 +62,8 @@ class SchemaGenerator:
     TIME_MATCHER = re.compile(r'^\d{1,2}:\d{1,2}:\d{1,2}(\.\d{1,6})?$')
 
     # Detect integers inside quotes.
-    INTEGER_MATCHER = re.compile(r'^-?\d+\.?(?:\d+[e|E]\+\d+)?$') # match scientific notation as well as (^-?\d+$)
+    # match scientific notation as well as (^-?\d+$)
+    INTEGER_MATCHER = re.compile(r'^-?\d+\.?(?:\d+[e|E]\+\d+)?$')
 
     # Max INTEGER value supported by 'bq load'.
     INTEGER_MAX_VALUE = 2**63 - 1

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -62,7 +62,7 @@ class SchemaGenerator:
     TIME_MATCHER = re.compile(r'^\d{1,2}:\d{1,2}:\d{1,2}(\.\d{1,6})?$')
 
     # Detect integers inside quotes.
-    INTEGER_MATCHER = re.compile(r'^[-]?\d+$')
+    INTEGER_MATCHER = re.compile(r'^-?\d+\.?(?:\d+[e|E]\+\d+)?$') # match scientific notation as well as (^-?\d+$)
 
     # Max INTEGER value supported by 'bq load'.
     INTEGER_MAX_VALUE = 2**63 - 1
@@ -536,6 +536,9 @@ class SchemaGenerator:
             else:
                 return 'INTEGER'
         elif isinstance(value, float):
+            # check if float is actually an integer. This could happen when scientific notation is expanded
+            if value.is_integer():
+                return 'INTEGER'
             return 'FLOAT'
         elif value is None:
             return '__null__'

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -537,7 +537,8 @@ class SchemaGenerator:
             else:
                 return 'INTEGER'
         elif isinstance(value, float):
-            # check if float is actually an integer. This could happen when scientific notation is expanded
+            # check if float is actually an integer.
+            # This could happen when scientific notation is expanded
             if value.is_integer():
                 return 'INTEGER'
             return 'FLOAT'

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -589,7 +589,8 @@ class SchemaGenerator:
             sanitize_names=self.sanitize_names,
         )
 
-    def run(self, input_file=sys.stdin, output_file=sys.stdout, ref_schema_map=None):
+    def run(self, input_file=sys.stdin, output_file=sys.stdout,
+            ref_schema_map=None):
         """Read the data records from the input_file and print out the BigQuery
         schema on the output_file. The error logs are printed on the sys.stderr.
         Args:
@@ -608,6 +609,7 @@ class SchemaGenerator:
             schema = self.flatten_schema(schema_map)
             json.dump(schema, output_file, indent=2)
             print(file=output_file)
+
 
 def json_reader(file):
     """A generator that converts an iterable of newline-delimited JSON objects
@@ -788,12 +790,13 @@ def flatten_schema_map(
             else:
                 new_value = value
             new_info[key] = new_value
-        # resolve collisions if the name "sanitizes" into a name that's already there
-        # sanitization should really happen much earlier in schema generation to avoid this mess
-        append=True
+        # resolve collisions if the name "sanitizes" into a name that's already
+        # there. Sanitization should really happen much earlier in schema
+        # generation to avoid this mess
+        append = True
         for i in schema:
             if new_info['name'] == i['name']:
-                append=False
+                append = False
                 break
         if append:
             schema.append(new_info)
@@ -803,28 +806,31 @@ def flatten_schema_map(
 def unflatten_schema_map(schema_map):
     """Converts the BigQuery schema into the 'schema_map'
     To test run
-            schema_map = flatten_schema_map(unflatten_schema_map(json.load(f, object_pairs_hook=OrderedDict))
+            schema_map = flatten_schema_map(unflatten_schema_map(json.load(f,
+                object_pairs_hook=OrderedDict))
     and then compare schema_map to the contents of f
     """
     if not isinstance(schema_map, list):
         raise Exception(
-            "Unexpected type '%s' for schema_map: %s" % (type(schema_map),json.dumps(schema_map)))
+            "Unexpected type '%s' for schema_map" % type(schema_map))
 
     # Build the BigQuery schema from the internal 'schema_map'.
     schema = OrderedDict()
     for s in schema_map:
-        entry={}
-        entry['status']='hard'
-        entry['filled']=True
-        # the if below is a bit awkward but it puts 'fileds' at the top in the order list. Really for beauty only.
-        entry['info']=OrderedDict()
+        entry = {}
+        entry['status'] = 'hard'
+        entry['filled'] = True
+        # the if below is a bit awkward but it puts 'fileds' at the top in
+        # the order list. Really for beauty only.
+        entry['info'] = OrderedDict()
         if 'fields' in s:
-            entry['info']['fields']=unflatten_schema_map(s['fields'])
-        entry['info']['mode']=s['mode']
-        entry['info']['name']=s['name']
-        entry['info']['type']=s['type']
-        schema[s['name']]=entry
+            entry['info']['fields'] = unflatten_schema_map(s['fields'])
+        entry['info']['mode'] = s['mode']
+        entry['info']['name'] = s['name']
+        entry['info']['type'] = s['type']
+        schema[s['name']] = entry
     return schema
+
 
 def json_full_path(base_path, key):
     """Return the dot-separated JSON full path to a particular key.
@@ -897,8 +903,10 @@ def main():
         generator.run()
     else:
         with open(args.augment) as f:
-            ref_schema_map = unflatten_schema_map(json.load(f, object_pairs_hook=OrderedDict))
+            ref_schema = json.load(f, object_pairs_hook=OrderedDict)
+            ref_schema_map = unflatten_schema_map(ref_schema)
         generator.run(ref_schema_map=ref_schema_map)
+
 
 if __name__ == '__main__':
     main()

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -145,10 +145,10 @@ class TestSchemaGenerator(unittest.TestCase):
                          generator.infer_value_type('-9223372036854775809'))
 
         # FLOAT
-        self.assertEqual('FLOAT', generator.infer_value_type(2.0))
+        self.assertEqual('FLOAT', generator.infer_value_type(2.2))
 
         # Quoted FLOAT
-        self.assertEqual('QFLOAT', generator.infer_value_type('3.0'))
+        self.assertEqual('QFLOAT', generator.infer_value_type('3.3'))
         self.assertEqual('QFLOAT', generator.infer_value_type('-5.4'))
 
         # RECORD
@@ -170,7 +170,7 @@ class TestSchemaGenerator(unittest.TestCase):
         self.assertEqual('INTEGER', generator.infer_value_type(1))
         self.assertEqual('STRING', generator.infer_value_type('1'))
 
-        self.assertEqual('FLOAT', generator.infer_value_type(1.0))
+        self.assertEqual('FLOAT', generator.infer_value_type(1.1))
         self.assertEqual('STRING', generator.infer_value_type('1.0'))
 
         self.assertEqual('BOOLEAN', generator.infer_value_type(True))
@@ -192,7 +192,7 @@ class TestSchemaGenerator(unittest.TestCase):
         self.assertEqual(('NULLABLE', 'INTEGER'),
                          generator.infer_bigquery_type(1))
         self.assertEqual(('NULLABLE', 'FLOAT'),
-                         generator.infer_bigquery_type(2.0))
+                         generator.infer_bigquery_type(2.2))
         # yapf: disable
         self.assertEqual(('NULLABLE', 'RECORD'),
                          generator.infer_bigquery_type({'a': 1, 'b': 2}))
@@ -223,7 +223,7 @@ class TestSchemaGenerator(unittest.TestCase):
         self.assertEqual(('REPEATED', 'INTEGER'),
                          generator.infer_bigquery_type([1, 2, 3]))
         self.assertEqual(('REPEATED', 'FLOAT'),
-                         generator.infer_bigquery_type([1.0, 2.0]))
+                         generator.infer_bigquery_type([1.1, 2.2]))
         # yapf: disable
         self.assertEqual(
             ('REPEATED', 'RECORD'),
@@ -250,7 +250,7 @@ class TestSchemaGenerator(unittest.TestCase):
         generator = SchemaGenerator()
 
         self.assertEqual('INTEGER', generator.infer_array_type([1, 1]))
-        self.assertEqual('FLOAT', generator.infer_array_type([1.0, 2.0]))
+        self.assertEqual('FLOAT', generator.infer_array_type([1.1, 2.2]))
         self.assertEqual('BOOLEAN', generator.infer_array_type([True, False]))
         self.assertEqual('STRING', generator.infer_array_type(['a', 'b']))
         self.assertEqual('DATE',
@@ -287,8 +287,8 @@ class TestSchemaGenerator(unittest.TestCase):
                              ['timestamp', '2018-02-09T10:44:00']))
 
         # Mixed FLOAT and INTEGER returns FLOAT
-        self.assertEqual('FLOAT', generator.infer_array_type([1, 2.0]))
-        self.assertEqual('FLOAT', generator.infer_array_type([1.0, 2]))
+        self.assertEqual('FLOAT', generator.infer_array_type([1, 2.2]))
+        self.assertEqual('FLOAT', generator.infer_array_type([1.1, 2]))
 
         # Invalid mixed arrays
         self.assertIsNone(generator.infer_array_type([None, 1]))


### PR DESCRIPTION
Added a way to augment existing schema, instead of generating one from the scratch. This is needed for importing multiple sets of data, where each only has a subset of all of the possible fields. Even if none of the data sets have complete list of fields, this option allows incremental expansion of the schema.

It is also helpful when the schema is hand-edited and you do not want to lose changes.