### PR TITLE
Add support and testing for 'dict' in SchemaGenerator (fixes #58)

### DIFF
--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -204,12 +204,12 @@ class SchemaGenerator:
                         raise json_object
                 else:
                     self.log_error(
-                        'Record should be a JSON Object but was a'
-                        f' {type(json_object)}'
+                        'Record should be a JSON Object '
+                        f'but was a {type(json_object)}'
                     )
                     if not self.ignore_invalid_lines:
-                        raise Exception(f'Record must be a JSON Object but was a'
-                                        f' {type(json_object)}')
+                        raise Exception(f'Record must be a JSON Object '
+                                        f'but was a {type(json_object)}')
         finally:
             logging.info(f'Processed {self.line_number} lines')
 
@@ -719,11 +719,11 @@ class SchemaGenerator:
 
 def json_reader(input_data):
     """A generator that converts an iterable of newline-delimited JSON objects
-    ('input_data' could be a 'list' for testing purposes) into an iterable of Python
-    dict objects. If the line cannot be parsed as JSON, the exception thrown by
-    the json.loads() is yielded back, instead of the json object. The calling
-    code can check for this exception with an isinstance() function, then
-    continue processing the rest of the file.
+    ('input_data' could be a 'list' for testing purposes) into an iterable of
+    Python dict objects. If the line cannot be parsed as JSON, the exception
+    thrown by the json.loads() is yielded back, instead of the json object.
+    The calling code can check for this exception with an isinstance() function,
+    then continue processing the rest of the file.
     """
     for line in input_data:
         try:

--- a/bigquery_schema_generator/generate_schema.py
+++ b/bigquery_schema_generator/generate_schema.py
@@ -108,12 +108,12 @@ class SchemaGenerator:
         # If CSV, force keep_nulls = True
         self.keep_nulls = True if (input_format == 'csv') else keep_nulls
 
-        # If JSON, sort the schema using the name of the column to be
+        # If JSON or dict, sort the schema using the name of the column to be
         # consistent with 'bq load'.
         # If CSV, preserve the original ordering because 'bq load` matches the
         # CSV column with the respective schema entry using the position of the
         # column in the schema.
-        self.sorted_schema = (input_format == 'json')
+        self.sorted_schema = (input_format in {'json', 'dict'})
 
         self.line_number = 0
         self.error_logs = []
@@ -121,8 +121,8 @@ class SchemaGenerator:
     def log_error(self, msg):
         self.error_logs.append({'line_number': self.line_number, 'msg': msg})
 
-    def deduce_schema(self, file, *, schema_map=None):
-        """Loop through each newlined-delimited line of 'file' and deduce the
+    def deduce_schema(self, input_data, *, schema_map=None):
+        """Loop through each element of 'input_data' and deduce the
         BigQuery schema. The schema is returned as a recursive map that contains
         both the database schema and some additional metadata about each entry.
         It has the following form:
@@ -171,9 +171,11 @@ class SchemaGenerator:
         """
 
         if self.input_format == 'csv':
-            reader = csv.DictReader(file)
+            reader = csv.DictReader(input_data)
         elif self.input_format == 'json' or self.input_format is None:
-            reader = json_reader(file)
+            reader = json_reader(input_data)
+        elif self.input_format == 'dict':
+            reader = input_data
         else:
             raise Exception(f"Unknown input_format '{self.input_format}'")
 
@@ -206,7 +208,8 @@ class SchemaGenerator:
                         f' {type(json_object)}'
                     )
                     if not self.ignore_invalid_lines:
-                        raise Exception('Record must be a JSON Object')
+                        raise Exception(f'Record must be a JSON Object but was a'
+                                        f' {type(json_object)}')
         finally:
             logging.info(f'Processed {self.line_number} lines')
 
@@ -714,15 +717,15 @@ class SchemaGenerator:
             print(file=output_file)
 
 
-def json_reader(file):
+def json_reader(input_data):
     """A generator that converts an iterable of newline-delimited JSON objects
-    ('file' could be a 'list' for testing purposes) into an iterable of Python
+    ('input_data' could be a 'list' for testing purposes) into an iterable of Python
     dict objects. If the line cannot be parsed as JSON, the exception thrown by
     the json.loads() is yielded back, instead of the json object. The calling
     code can check for this exception with an isinstance() function, then
     continue processing the rest of the file.
     """
-    for line in file:
+    for line in input_data:
         try:
             yield json.loads(line)
         except Exception as e:

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -470,13 +470,15 @@ class TestDataChunksFromFile(unittest.TestCase):
                 ignore_invalid_lines=ignore_invalid_lines)
             existing_schema_map = None
             if existing_schema:
-                existing_schema_map = bq_schema_to_map(json.loads(existing_schema))
+                existing_schema_map = \
+                    bq_schema_to_map(json.loads(existing_schema))
             schema_map, error_logs = generator.deduce_schema(
                 records, schema_map=existing_schema_map)
             schema = generator.flatten_schema(schema_map)
 
             # Check the schema, preserving order
-            expected = json.loads(expected_schema, object_pairs_hook=OrderedDict)
+            expected = json.loads(expected_schema,
+                                  object_pairs_hook=OrderedDict)
             self.assertEqual(expected, schema)
 
             # Check the error messages


### PR DESCRIPTION
As proposed in #47 and #58, this PR implements the support of passing 'dict' as `input_format` to `SchemaGenerator`.

Usage example:
```python
from bigquery_schema_generator.generate_schema import SchemaGenerator

data = [{"first_column": 1, "second_column": "value"},
{"first_column": 2, "second_column": "another value"}]  # any iterable of dicts
generator = SchemaGenerator(input_format='dict')
schema_map, error_logs = generator.deduce_schema(data)
```

Implementations details:
* As suggested by @bxparks in #47, I renamed `file` to `input_data` in `deduce_schema` and `json_reader` functions and added `elif self.input_format == 'dict': reader = input_data` to `deduce_schema`
* For tests I did the following trick: for each JSON test data chunk in `testdata.txt` I convert it to an iterable of dicts using `json_reader` and test with `input_format='dict'; input_data = json_reader(records)`. It's exactly what's happening in `deduce_schema` when it reads `json` so the results of tests for dicts will be the same as for `input_format='json'; input_data = records`.

Please let me know what I've forgotten to change (at least we'd need to update Readme).