### PR TITLE
Add dataclass support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+
+# Python
+venv

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author_email='brian@xparks.net',
     license='Apache 2.0',
     packages=['bigquery_schema_generator'],
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     entry_points={
         'console_scripts': [
             'generate-schema = bigquery_schema_generator.generate_schema:main'


### PR DESCRIPTION
Support python [dataclasses](https://docs.python.org/3/library/dataclasses.html) as an input type when generating BigQuery schemas.

* This requires a bump to python 3.8 (if we want to use native get_types and get_origins). Alternatively we can bump to 3.7 if we want to support native dataclasses. Alternatively to that, we can install dataclasses as a dependency.